### PR TITLE
fix #16: monitor loop, edge targets for index nodes, and highlight coloring

### DIFF
--- a/gitplot/builder.py
+++ b/gitplot/builder.py
@@ -24,7 +24,7 @@ class GraphBuilder:
     """Builds a graphviz.Digraph from repo data.
 
     Instantiate once per render; call build() to produce the Digraph.
-    After build(), node_ids contains the IDs of every node added—used by
+    After build(), node_ids contains the IDs of every node added -- used by
     Monitor to track what's new between renders.
     """
 
@@ -34,13 +34,14 @@ class GraphBuilder:
         rank_direction: str = "RL",
         output_format: str = "svg",
         commit_details: bool = False,
-        highlight_ids: Optional[set[str]] = None,
+        highlight_ids: Optional[frozenset[str]] = None,
     ) -> None:
         self.mode = mode
         self.rank_direction = rank_direction
         self.output_format = output_format
         self.commit_details = commit_details
-        self.highlight_ids: set[str] = highlight_ids or set()
+        # None means "no highlighting"; a frozenset means "highlight nodes absent from this set"
+        self.highlight_ids: Optional[frozenset[str]] = highlight_ids
 
         self._rendered_nodes: set[str] = set()
         self._rendered_edges: set[tuple[str, str]] = set()
@@ -90,16 +91,16 @@ class GraphBuilder:
             if ref.is_head:
                 self._add_node(dg, ref_id, label="HEAD", type_key="ref")
                 if graph.head_branch_path:
-                    # Non-detached: HEAD → branch ref node
+                    # Non-detached: HEAD -> branch ref node
                     self._add_edge(dg, ref_id, graph.head_branch_path, label="HEAD")
                     # The branch ref will walk the commit chain
                     continue
                 else:
-                    # Detached HEAD → commit
+                    # Detached HEAD -> commit
                     self._add_edge(dg, ref_id, ref.commit_hexsha, label="HEAD")
 
             elif ref.is_tag and ref.tag_object_hexsha:
-                # Annotated tag: ref → tag-object → commit
+                # Annotated tag: ref -> tag-object -> commit
                 self._add_node(dg, ref_id, label=ref.name, type_key="tag")
                 tag_obj_id = ref.tag_object_hexsha
                 self._add_node(dg, tag_obj_id, label=tag_obj_id[:hl], type_key="tag")
@@ -200,7 +201,7 @@ class GraphBuilder:
         cd = graph.commits.get(hexsha)
         label = hexsha[:hl]
         if self.commit_details and cd:
-            msg = cd.short_message[:40] + ("…" if len(cd.short_message) > 40 else "")
+            msg = cd.short_message[:40] + ("..." if len(cd.short_message) > 40 else "")
             label = "\n".join([label, cd.author, msg, cd.date_iso[:10]])
 
         self._add_node(dg, hexsha, label=label, type_key="commit")
@@ -249,7 +250,7 @@ class GraphBuilder:
         if index_state.staged:
             self._add_node(dg, "Staged Changes", label="Staged Changes", type_key="staged_changes")
             for sf in index_state.staged:
-                node_id = f"staged:{sf.path}"
+                node_id = f"staged|{sf.path}"
                 label = f"{sf.path}\n{sf.hexsha[:hl]}"
                 self._add_node(dg, node_id, label=label, type_key="staged_changes")
                 self._add_edge(dg, "Staged Changes", node_id, label=sf.path)
@@ -259,7 +260,7 @@ class GraphBuilder:
                 dg, "Unstaged Changes", label="Unstaged Changes", type_key="unstaged_changes"
             )
             for uf in index_state.unstaged:
-                node_id = f"unstaged:{uf.path}"
+                node_id = f"unstaged|{uf.path}"
                 label = f"{uf.path}\n{uf.workspace_hexsha[:hl]}"
                 self._add_node(dg, node_id, label=label, type_key="unstaged_changes")
                 self._add_edge(dg, "Unstaged Changes", node_id, label=uf.path)
@@ -267,7 +268,7 @@ class GraphBuilder:
         if index_state.untracked:
             self._add_node(dg, "Untracked", label="Untracked", type_key="untracked_file")
             for path in index_state.untracked:
-                node_id = f"untracked:{path}"
+                node_id = f"untracked|{path}"
                 self._add_node(dg, node_id, label=path, type_key="untracked_file")
                 self._add_edge(dg, "Untracked", node_id, label=path)
 
@@ -284,10 +285,10 @@ class GraphBuilder:
             type_key = "tag" if node.is_tag else "ref"
             label = node.name
             if node.is_head:
-                label = f"HEAD→{node.name}"
+                label = f"HEAD->{node.name}"
             self._add_node(dg, node.name, label=label, type_key=type_key)
 
-        # Fork commit nodes — shown as commit-style nodes labelled with short hash
+        # Fork commit nodes -- shown as commit-style nodes labelled with short hash
         for fork in topo.fork_commits:
             label = f"fork\n{fork.short_hexsha}"
             self._add_node(dg, fork.hexsha, label=label, type_key="commit")
@@ -310,8 +311,13 @@ class GraphBuilder:
         return len(cd.parents) == 1 and len(cd.children) == 1 and len(cd.refs) == 0
 
     def _colors_for(self, node_id: str, type_key: str) -> NodeColors:
-        """Return colors, substituting highlight colors for new nodes."""
-        if node_id in self.highlight_ids:
+        """Return colors, substituting highlight colors for new nodes.
+
+        highlight_ids holds node IDs from the *previous* render.  A node absent
+        from that set is new and gets the highlight color.  None means monitoring
+        is not active and no node is highlighted.
+        """
+        if self.highlight_ids is not None and node_id not in self.highlight_ids:
             return SCHEME["new_node"]
         return SCHEME.get(type_key, SCHEME["commit"])
 

--- a/gitplot/cli.py
+++ b/gitplot/cli.py
@@ -136,7 +136,7 @@ def _render_once(
         repo.get_branch_topology(args.exclude_remotes) if args.mode == "branch" else None
     )
 
-    # Branch mode flows forward in time left→right; commit modes flow right→left.
+    # Branch mode flows forward in time left-to-right; commit modes flow right-to-left.
     if args.rank_direction is not None:
         rank_direction = args.rank_direction
     elif args.mode == "branch":
@@ -191,9 +191,8 @@ def main(argv: Optional[list[str]] = None) -> None:
     try:
         while True:
             mon.wait()
-            logging.info("Change detected — re-rendering…")
-            highlight = mon.prev_node_ids if args.mode == "verbose" else None
-            node_ids = _render_once(args, renderer, highlight_ids=highlight)
+            logging.info("Change detected - re-rendering...")
+            node_ids = _render_once(args, renderer, highlight_ids=mon.prev_node_ids)
             mon.update(node_ids)
     except KeyboardInterrupt:
         logging.info("Monitor stopped.")

--- a/gitplot/monitor.py
+++ b/gitplot/monitor.py
@@ -95,6 +95,14 @@ class Monitor:
         # Drain any events that fired during the settle window
         self._event.clear()
 
-    def update(self, node_ids: frozenset[str]) -> None:
-        """Record the node IDs from the most recent render."""
+    def update(self, node_ids: frozenset[str], drain_seconds: float = 0.3) -> None:
+        """Record node IDs from the most recent render and drain self-induced events.
+
+        GitPython read operations (e.g. index diff) can trigger git's stat-cache
+        refresh, which writes .git/index and fires a watchdog event.  Sleeping
+        briefly after the render lets those events arrive, then clearing the flag
+        prevents them from spuriously re-triggering the loop.
+        """
         self.prev_node_ids = node_ids
+        time.sleep(drain_seconds)
+        self._event.clear()

--- a/tests/golden/complex_branch.dot
+++ b/tests/golden/complex_branch.dot
@@ -1,6 +1,6 @@
 digraph {
 	graph [rankdir=RL]
-	develop [label="HEAD→develop" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	develop [label="HEAD->develop" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 	"feature/alpha" [label="feature/alpha" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 	"feature/beta" [label="feature/beta" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 	main [label=main color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]

--- a/tests/golden/complex_branch.mermaid
+++ b/tests/golden/complex_branch.mermaid
@@ -1,5 +1,5 @@
 flowchart RL
-    develop["HEAD→develop"]
+    develop["HEAD->develop"]
     feature_alpha["feature/alpha"]
     feature_beta["feature/beta"]
     main["main"]

--- a/tests/golden/complex_verbose.dot
+++ b/tests/golden/complex_verbose.dot
@@ -163,14 +163,14 @@ a1730" color="0.556 1.000 1.000" fillcolor="0.556 0.100 1.000" penwidth=2 style=
 	"112885a309337593323175787051795afbcd2ad7" -> c2f575b00ce2b17e91b59cc868ad7ccac2a07530 [label=tree]
 	"112885a309337593323175787051795afbcd2ad7" -> "790db164f18098ef413853e56f7d93e70a2c187a" [label=parent]
 	"Staged Changes" [label="Staged Changes" color="0.667 1.000 1.000" fillcolor="0.667 0.100 1.000" penwidth=2 style=filled]
-	"staged:index_file.txt" [label="index_file.txt
+	"staged|index_file.txt" [label="index_file.txt
 00000" color="0.667 1.000 1.000" fillcolor="0.667 0.100 1.000" penwidth=2 style=filled]
-	"Staged Changes" -> staged:"index_file.txt" [label="index_file.txt"]
+	"Staged Changes" -> "staged|index_file.txt" [label="index_file.txt"]
 	"Unstaged Changes" [label="Unstaged Changes" color="0.778 1.000 1.000" fillcolor="0.778 0.100 1.000" penwidth=2 style=filled]
-	"unstaged:develop.txt" [label="develop.txt
+	"unstaged|develop.txt" [label="develop.txt
 1a892" color="0.778 1.000 1.000" fillcolor="0.778 0.100 1.000" penwidth=2 style=filled]
-	"Unstaged Changes" -> unstaged:"develop.txt" [label="develop.txt"]
+	"Unstaged Changes" -> "unstaged|develop.txt" [label="develop.txt"]
 	Untracked [label=Untracked color="0.889 1.000 1.000" fillcolor="0.889 0.100 1.000" penwidth=2 style=filled]
-	"untracked:scratch.txt" [label="scratch.txt" color="0.889 1.000 1.000" fillcolor="0.889 0.100 1.000" penwidth=2 style=filled]
-	Untracked -> untracked:"scratch.txt" [label="scratch.txt"]
+	"untracked|scratch.txt" [label="scratch.txt" color="0.889 1.000 1.000" fillcolor="0.889 0.100 1.000" penwidth=2 style=filled]
+	Untracked -> "untracked|scratch.txt" [label="scratch.txt"]
 }

--- a/tests/golden/complex_verbose.mermaid
+++ b/tests/golden/complex_verbose.mermaid
@@ -154,9 +154,9 @@ flowchart RL
     c33e73c6409632d1e00d353d3496d65cf06675df --> 112885a309337593323175787051795afbcd2ad7
     112885a309337593323175787051795afbcd2ad7 --> c2f575b00ce2b17e91b59cc868ad7ccac2a07530
     112885a309337593323175787051795afbcd2ad7 --> 790db164f18098ef413853e56f7d93e70a2c187a
-    Staged_Changes --> staged
-    Unstaged_Changes --> unstaged
-    Untracked --> untracked
+    Staged_Changes -->|"index_file.txt"| staged_index_file_txt
+    Unstaged_Changes -->|"develop.txt"| unstaged_develop_txt
+    Untracked -->|"scratch.txt"| untracked_scratch_txt
     style HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style refs_heads_develop fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style 790db164f18098ef413853e56f7d93e70a2c187a fill:#f6ffe5,stroke:#aaff00,stroke-width:2px

--- a/tests/golden/shallow_clone_branch.dot
+++ b/tests/golden/shallow_clone_branch.dot
@@ -1,4 +1,4 @@
 digraph {
 	graph [rankdir=RL]
-	main [label="HEAD→main" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	main [label="HEAD->main" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 }

--- a/tests/golden/shallow_clone_branch.mermaid
+++ b/tests/golden/shallow_clone_branch.mermaid
@@ -1,3 +1,3 @@
 flowchart RL
-    main["HEAD→main"]
+    main["HEAD->main"]
     style main fill:#ffe5e5,stroke:#ff0000,stroke-width:2px

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -239,6 +239,47 @@ def test_verbose_untracked_file(repo: RepoTools):
     assert "new.txt" in dg.source
 
 
+def test_verbose_untracked_edge_connects_to_file_node(repo: RepoTools):
+    """Edge from 'Untracked' must point to the individual file node, not a phantom node."""
+    repo.write("a.txt")
+    repo.commit("first")
+    repo.write("new.txt")
+    dg, _, _, _ = _build(str(repo.path), mode="verbose")
+    src = dg.source
+    # The edge must go to the file node, not back to an implicit 'untracked' node
+    assert edge_in(src, "Untracked", "untracked|new.txt"), (
+        "Edge must connect 'Untracked' container to 'untracked|new.txt' file node"
+    )
+    assert node_in(src, "untracked|new.txt"), "Individual untracked file node must exist"
+
+
+def test_verbose_staged_edge_connects_to_file_node(repo: RepoTools):
+    """Edge from 'Staged Changes' must point to the individual file node."""
+    repo.write("a.txt")
+    repo.commit("first")
+    repo.write("b.txt", content="staged")
+    repo._run(["git", "add", "b.txt"])
+    dg, _, _, _ = _build(str(repo.path), mode="verbose")
+    src = dg.source
+    assert edge_in(src, "Staged Changes", "staged|b.txt"), (
+        "Edge must connect 'Staged Changes' to 'staged|b.txt' file node"
+    )
+    assert node_in(src, "staged|b.txt"), "Individual staged file node must exist"
+
+
+def test_verbose_unstaged_edge_connects_to_file_node(repo: RepoTools):
+    """Edge from 'Unstaged Changes' must point to the individual file node."""
+    repo.write("a.txt", content="original")
+    repo.commit("first")
+    repo.write("a.txt", content="modified")
+    dg, _, _, _ = _build(str(repo.path), mode="verbose")
+    src = dg.source
+    assert edge_in(src, "Unstaged Changes", "unstaged|a.txt"), (
+        "Edge must connect 'Unstaged Changes' to 'unstaged|a.txt' file node"
+    )
+    assert node_in(src, "unstaged|a.txt"), "Individual unstaged file node must exist"
+
+
 # ---------------------------------------------------------------------------
 # Branch mode
 # ---------------------------------------------------------------------------
@@ -330,20 +371,49 @@ def test_branch_mode_single_branch(repo: RepoTools):
 # ---------------------------------------------------------------------------
 
 
-def test_highlight_ids_applied(repo: RepoTools):
-    """Nodes in highlight_ids receive the new_node color style."""
+def test_highlight_new_node_not_in_prev_render(repo: RepoTools):
+    """Nodes absent from highlight_ids (prev render) receive the new_node color."""
+    repo.write("a.txt")
+    repo.commit("first")
+    from gitplot.colors import SCHEME
+
+    # Pass an empty frozenset as highlight_ids (prev render had no nodes).
+    # sha is NOT in the prev render, so it should be highlighted.
+    dg, _, _, _ = _build(str(repo.path), highlight_ids=frozenset())
+    new_fill = SCHEME["new_node"].fill
+    assert new_fill in dg.source, "New node (not in prev render) must use new_node fill color"
+
+
+def test_highlight_old_node_not_highlighted(repo: RepoTools):
+    """Nodes present in highlight_ids (prev render) keep their normal color."""
     repo.write("a.txt")
     sha = repo.commit("first")
+    from gitplot.colors import SCHEME
 
-    # Pretend sha is a NEW node (not in prev render)
-    # highlight_ids contains the PREVIOUS render's nodes; new nodes are those NOT in it.
-    # So pass empty set as highlight_ids to mark nothing as new.
-    # To mark sha as highlighted, we need to use it differently:
-    # highlight_ids in GraphBuilder marks nodes that ARE new (not in prev render).
-    dg, _, _, _ = _build(str(repo.path), highlight_ids={sha})
-    # The sha node should use the new_node color scheme (golden fill)
-    # Check that the node is present (it was highlighted)
-    assert node_in(dg.source, sha)
+    # Pass sha as already known (in the previous render) — it should NOT be highlighted.
+    dg, _, _, _ = _build(str(repo.path), highlight_ids=frozenset({sha}))
+    new_fill = SCHEME["new_node"].fill
+    # The commit node is sha; it's in highlight_ids so it should use normal commit color.
+    commit_fill = SCHEME["commit"].fill
+    assert commit_fill in dg.source, "Known node (in prev render) must keep commit fill color"
+    # sha's node should not use new_node fill when it's a known node and is the ONLY node
+    # (all other nodes like refs would still be new, so just check sha's own attrs)
+    src = dg.source
+    # The sha node line should contain commit fill, not new_node fill
+    sha_line = next((ln for ln in src.splitlines() if sha[:5] in ln and "fillcolor" in ln), None)
+    assert sha_line is not None
+    assert new_fill not in sha_line, "sha node (in prev render) must not use new_node fill"
+
+
+def test_highlight_none_disables_highlighting(repo: RepoTools):
+    """When highlight_ids is None, no node receives the new_node color."""
+    repo.write("a.txt")
+    repo.commit("first")
+    from gitplot.colors import SCHEME
+
+    dg, _, _, _ = _build(str(repo.path), highlight_ids=None)
+    new_fill = SCHEME["new_node"].fill
+    assert new_fill not in dg.source, "highlight_ids=None must produce no highlighted nodes"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,59 @@
+"""Tests for Monitor: post-render drain prevents self-induced re-render loops."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from gitplot.monitor import Monitor
+
+
+def _make_monitor(tmp_path: Path) -> Monitor:
+    output_path = tmp_path / "gitplot.svg"
+    return Monitor(repo_path=str(tmp_path), output_path=output_path)
+
+
+def test_monitor_update_drains_pending_event(tmp_path: Path) -> None:
+    """update() clears any events that fired during rendering (drain_seconds=0)."""
+    mon = _make_monitor(tmp_path)
+    # Simulate a filesystem event that arrives while rendering
+    mon._event.set()
+    mon.update(frozenset(["node1"]), drain_seconds=0)
+    assert not mon._event.is_set(), "update() must drain pending events so the loop does not spin"
+
+
+def test_monitor_update_stores_node_ids(tmp_path: Path) -> None:
+    """update() records the latest node IDs for highlight diffing."""
+    mon = _make_monitor(tmp_path)
+    ids = frozenset(["a", "b", "c"])
+    mon.update(ids, drain_seconds=0)
+    assert mon.prev_node_ids == ids
+
+
+def test_monitor_wait_returns_after_event(tmp_path: Path) -> None:
+    """wait() blocks until an event fires, then returns."""
+    mon = _make_monitor(tmp_path)
+    mon.start()
+    try:
+        # Fire an event from a background thread with a short delay
+        def fire():
+            import time
+
+            time.sleep(0.05)
+            mon._event.set()
+
+        t = threading.Thread(target=fire, daemon=True)
+        t.start()
+        mon.wait(settle_seconds=0)  # zero settle so the test stays fast
+        t.join(timeout=2)
+    finally:
+        mon.stop()
+
+
+def test_monitor_ignores_output_path(tmp_path: Path) -> None:
+    """Events for the output file itself are ignored to prevent self-triggering."""
+    output_path = tmp_path / "gitplot.svg"
+    mon = Monitor(repo_path=str(tmp_path), output_path=output_path)
+    # Simulate an event on the output file
+    mon._handler._handle(str(output_path))
+    assert not mon._event.is_set(), "Events on the output file must be filtered"


### PR DESCRIPTION
Closes #16.

## Summary

- **Bug 1 (monitor re-render loop):** `Monitor.update()` now sleeps briefly after storing node IDs and clears the watchdog event, discarding stat-cache refreshes that `GitPython`'s `index.diff()` writes to `.git/index` during rendering. Without this drain the loop would re-fire on every render.

- **Bug 2 (wrong edge targets in verbose mode):** Replaced `:` with `|` as the node-ID separator for staged/unstaged/untracked file nodes (`"staged|path"` etc.). The graphviz Python library's `_quote_edge()` splits on `:` and treats the suffix as a DOT port name, so edges landed on a phantom node named `staged` / `unstaged` / `untracked` instead of the actual file nodes.

- **Bug 3 (all nodes turn yellow):** Fixed `GraphBuilder._colors_for()` to highlight nodes *absent* from `highlight_ids` (new nodes not seen in the previous render) rather than nodes *present* in it (old nodes). Also changed `highlight_ids` type to `Optional[frozenset[str]]` — `None` means no highlighting, a frozenset means "highlight nodes missing from this set" — and the monitor loop now passes `prev_node_ids` for **all modes**, not only verbose.

- **Non-ASCII chars:** Replaced all `—`, `→`, and `…` in `builder.py` and `cli.py` with ASCII equivalents (`--`, `->`, `...`).

## Test plan

- [ ] All new tests fail before the fix, pass after: `test_monitor_update_drains_pending_event`, `test_verbose_{untracked,staged,unstaged}_edge_connects_to_file_node`, `test_highlight_{new_node_not_in_prev_render,old_node_not_highlighted,none_disables_highlighting}`
- [ ] `ruff check . && ruff format --check .` — clean
- [ ] `pytest -v` — 104/104 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)