### PR TITLE
feat #24: show ORIG_HEAD, MERGE_HEAD, CHERRY_PICK_HEAD in graph

### DIFF
--- a/gitplot/repo.py
+++ b/gitplot/repo.py
@@ -470,6 +470,19 @@ class GitRepo:
                 )
             )
 
+        # ORIG_HEAD / MERGE_HEAD / CHERRY_PICK_HEAD — written during resets, merges, cherry-picks
+        for special_name in ("ORIG_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD"):
+            sp_sha = self._read_simple_ref(special_name)
+            if sp_sha and special_name not in seen:
+                seen.add(special_name)
+                refs.append(
+                    RefInfo(
+                        path=special_name,
+                        name=special_name,
+                        commit_hexsha=sp_sha,
+                    )
+                )
+
         if include_stash:
             for sha, label in self._collect_stash_entries():
                 path = f"stash/{label}"
@@ -496,6 +509,19 @@ class GitRepo:
             with open(path) as fh:
                 sha = fh.readline().split("\t")[0].strip()
             # Validate: must look like a hex SHA and resolve to a real commit
+            if len(sha) >= 40 and all(c in "0123456789abcdefABCDEF" for c in sha):
+                self._repo.commit(sha)  # raises if not in object store
+                return sha
+        except Exception:
+            pass
+        return None
+
+    def _read_simple_ref(self, name: str) -> Optional[str]:
+        """Return the commit SHA from .git/<name>, or None if absent/invalid."""
+        path = os.path.join(self._repo.git_dir, name)
+        try:
+            with open(path) as fh:
+                sha = fh.readline().strip()
             if len(sha) >= 40 and all(c in "0123456789abcdefABCDEF" for c in sha):
                 self._repo.commit(sha)  # raises if not in object store
                 return sha

--- a/tests/golden/complex_normal.dot
+++ b/tests/golden/complex_normal.dot
@@ -56,4 +56,6 @@ v1.0" color="0.111 1.000 1.000" fillcolor="0.111 0.100 1.000" penwidth=2 style=f
 	"68ab57a3957981ada1d7d99f5ed25152cf0c89d8" -> de59f3a1667fc051ccc0b0682694585e36040bf4 [label=commit]
 	FETCH_HEAD [label=FETCH_HEAD color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 	FETCH_HEAD -> d18f056029432df7a41eacf452447a111f0f4a12 [label=remote]
+	ORIG_HEAD [label=ORIG_HEAD color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	ORIG_HEAD -> "790db164f18098ef413853e56f7d93e70a2c187a" [label=remote]
 }

--- a/tests/golden/complex_normal.mermaid
+++ b/tests/golden/complex_normal.mermaid
@@ -20,6 +20,7 @@ flowchart RL
     refs_tags_v1_0["tag<br/>v1.0"]
     68ab57a3957981ada1d7d99f5ed25152cf0c89d8["tag<br/>68ab5"]
     FETCH_HEAD["FETCH_HEAD"]
+    ORIG_HEAD["ORIG_HEAD"]
     HEAD --> refs_heads_develop
     refs_heads_develop --> 790db164f18098ef413853e56f7d93e70a2c187a
     790db164f18098ef413853e56f7d93e70a2c187a --> 0b18da950bf84d50fbc7562a4747f13094fc85df
@@ -41,6 +42,7 @@ flowchart RL
     refs_tags_v1_0 --> 68ab57a3957981ada1d7d99f5ed25152cf0c89d8
     68ab57a3957981ada1d7d99f5ed25152cf0c89d8 --> de59f3a1667fc051ccc0b0682694585e36040bf4
     FETCH_HEAD --> d18f056029432df7a41eacf452447a111f0f4a12
+    ORIG_HEAD --> 790db164f18098ef413853e56f7d93e70a2c187a
     style HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style refs_heads_develop fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style 790db164f18098ef413853e56f7d93e70a2c187a fill:#f6ffe5,stroke:#aaff00,stroke-width:2px
@@ -62,3 +64,4 @@ flowchart RL
     style refs_tags_v1_0 fill:#fff6e5,stroke:#ffa900,stroke-width:2px
     style 68ab57a3957981ada1d7d99f5ed25152cf0c89d8 fill:#fff6e5,stroke:#ffa900,stroke-width:2px
     style FETCH_HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
+    style ORIG_HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px

--- a/tests/golden/complex_verbose.dot
+++ b/tests/golden/complex_verbose.dot
@@ -173,6 +173,8 @@ v1.0" color="0.111 1.000 1.000" fillcolor="0.111 0.100 1.000" penwidth=2 style=f
 	"68ab57a3957981ada1d7d99f5ed25152cf0c89d8" -> de59f3a1667fc051ccc0b0682694585e36040bf4 [label=commit]
 	FETCH_HEAD [label=FETCH_HEAD color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 	FETCH_HEAD -> d18f056029432df7a41eacf452447a111f0f4a12 [label=remote]
+	ORIG_HEAD [label=ORIG_HEAD color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	ORIG_HEAD -> "790db164f18098ef413853e56f7d93e70a2c187a" [label=remote]
 	"stash/stash@{0}" [label="stash@{0}" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
 	"stash/stash@{0}" -> c33e73c6409632d1e00d353d3496d65cf06675df [label=remote]
 	c33e73c6409632d1e00d353d3496d65cf06675df [label="commit

--- a/tests/golden/complex_verbose.mermaid
+++ b/tests/golden/complex_verbose.mermaid
@@ -45,6 +45,7 @@ flowchart RL
     refs_tags_v1_0["tag<br/>v1.0"]
     68ab57a3957981ada1d7d99f5ed25152cf0c89d8["tag<br/>68ab5"]
     FETCH_HEAD["FETCH_HEAD"]
+    ORIG_HEAD["ORIG_HEAD"]
     stash_stash__0_["stash@{0}"]
     c33e73c6409632d1e00d353d3496d65cf06675df["commit<br/>c33e7"]
     c2f575b00ce2b17e91b59cc868ad7ccac2a07530["tree<br/>c2f57"]
@@ -143,6 +144,7 @@ flowchart RL
     refs_tags_v1_0 --> 68ab57a3957981ada1d7d99f5ed25152cf0c89d8
     68ab57a3957981ada1d7d99f5ed25152cf0c89d8 --> de59f3a1667fc051ccc0b0682694585e36040bf4
     FETCH_HEAD --> d18f056029432df7a41eacf452447a111f0f4a12
+    ORIG_HEAD --> 790db164f18098ef413853e56f7d93e70a2c187a
     stash_stash__0_ --> c33e73c6409632d1e00d353d3496d65cf06675df
     c33e73c6409632d1e00d353d3496d65cf06675df --> c2f575b00ce2b17e91b59cc868ad7ccac2a07530
     c2f575b00ce2b17e91b59cc868ad7ccac2a07530 -->|"README.md"| 303ddddd86883f5558adc9d682135c455484e2e5
@@ -203,6 +205,7 @@ flowchart RL
     style refs_tags_v1_0 fill:#fff6e5,stroke:#ffa900,stroke-width:2px
     style 68ab57a3957981ada1d7d99f5ed25152cf0c89d8 fill:#fff6e5,stroke:#ffa900,stroke-width:2px
     style FETCH_HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
+    style ORIG_HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style stash_stash__0_ fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style c33e73c6409632d1e00d353d3496d65cf06675df fill:#f6ffe5,stroke:#aaff00,stroke-width:2px
     style c2f575b00ce2b17e91b59cc868ad7ccac2a07530 fill:#e5fff6,stroke:#00ffa9,stroke-width:2px

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -974,6 +974,175 @@ def test_fetch_head_malformed_no_crash(repo: RepoTools):
 
 
 # ---------------------------------------------------------------------------
+# ORIG_HEAD / MERGE_HEAD / CHERRY_PICK_HEAD support (issue #24)
+# ---------------------------------------------------------------------------
+
+
+def _write_simple_ref(repo_path: Path, name: str, sha: str) -> None:
+    """Write .git/<name> containing sha, simulating a git operation that leaves the ref."""
+    (repo_path / ".git" / name).write_text(sha + "\n")
+
+
+def test_orig_head_normal_mode_ref_node_appears(repo: RepoTools):
+    """ORIG_HEAD appears as a ref node in normal mode when the file exists."""
+    repo.write("a.txt")
+    sha = repo.commit("first")
+    _write_simple_ref(repo.path, "ORIG_HEAD", sha)
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert node_in(dg.source, "ORIG_HEAD")
+
+
+def test_orig_head_normal_mode_edge_to_commit(repo: RepoTools):
+    """ORIG_HEAD ref node has an edge to the commit it points at."""
+    repo.write("a.txt")
+    sha = repo.commit("first")
+    _write_simple_ref(repo.path, "ORIG_HEAD", sha)
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert edge_in(dg.source, "ORIG_HEAD", sha)
+
+
+def test_orig_head_after_real_reset(repo: RepoTools):
+    """ORIG_HEAD created by git reset --hard points at the pre-reset commit."""
+    repo.write("a.txt")
+    repo.commit("first")
+    repo.write("b.txt")
+    sha2 = repo.commit("second")
+    repo._run(["git", "reset", "--hard", "HEAD~1"])
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert node_in(dg.source, "ORIG_HEAD")
+    # ORIG_HEAD records where HEAD was *before* the reset, i.e. the second commit
+    assert edge_in(dg.source, "ORIG_HEAD", sha2)
+
+
+def test_orig_head_absent_no_phantom_node(repo: RepoTools):
+    """When .git/ORIG_HEAD doesn't exist, no ORIG_HEAD node appears."""
+    repo.write("a.txt")
+    repo.commit("first")
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert "ORIG_HEAD" not in dg.source
+
+
+def test_orig_head_malformed_no_crash(repo: RepoTools):
+    """A malformed ORIG_HEAD file doesn't crash gitplot."""
+    repo.write("a.txt")
+    repo.commit("first")
+    _write_simple_ref(repo.path, "ORIG_HEAD", "not-a-valid-sha")
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert isinstance(dg.source, str)
+
+
+def test_merge_head_normal_mode_ref_node_appears(repo: RepoTools):
+    """MERGE_HEAD appears as a ref node in normal mode when the file exists."""
+    repo.write("a.txt")
+    sha = repo.commit("first")
+    _write_simple_ref(repo.path, "MERGE_HEAD", sha)
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert node_in(dg.source, "MERGE_HEAD")
+
+
+def test_merge_head_edge_to_commit(repo: RepoTools):
+    """MERGE_HEAD ref node has an edge to the commit it points at."""
+    repo.write("a.txt")
+    sha = repo.commit("first")
+    _write_simple_ref(repo.path, "MERGE_HEAD", sha)
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert edge_in(dg.source, "MERGE_HEAD", sha)
+
+
+def test_merge_head_after_real_conflicting_merge(repo: RepoTools):
+    """MERGE_HEAD written by a conflicting merge appears in the graph."""
+    import subprocess
+
+    repo.write("file.txt", "base")
+    repo.commit("base")
+    repo.checkout("feature", new=True)
+    repo.write("file.txt", "feature version")
+    feature_sha = repo.commit("feature change")
+    repo.checkout("main")
+    repo.write("file.txt", "main version")
+    repo.commit("main change")
+    try:
+        repo._run(["git", "merge", "feature"])
+    except subprocess.CalledProcessError:
+        pass  # conflict is expected
+    assert (repo.path / ".git" / "MERGE_HEAD").exists(), "git merge should have written MERGE_HEAD"
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert node_in(dg.source, "MERGE_HEAD")
+    assert edge_in(dg.source, "MERGE_HEAD", feature_sha)
+
+
+def test_merge_head_absent_no_phantom_node(repo: RepoTools):
+    """When .git/MERGE_HEAD doesn't exist, no MERGE_HEAD node appears."""
+    repo.write("a.txt")
+    repo.commit("first")
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert "MERGE_HEAD" not in dg.source
+
+
+def test_cherry_pick_head_normal_mode_ref_node_appears(repo: RepoTools):
+    """CHERRY_PICK_HEAD appears as a ref node in normal mode when the file exists."""
+    repo.write("a.txt")
+    sha = repo.commit("first")
+    _write_simple_ref(repo.path, "CHERRY_PICK_HEAD", sha)
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert node_in(dg.source, "CHERRY_PICK_HEAD")
+
+
+def test_cherry_pick_head_edge_to_commit(repo: RepoTools):
+    """CHERRY_PICK_HEAD ref node has an edge to the commit it points at."""
+    repo.write("a.txt")
+    sha = repo.commit("first")
+    _write_simple_ref(repo.path, "CHERRY_PICK_HEAD", sha)
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert edge_in(dg.source, "CHERRY_PICK_HEAD", sha)
+
+
+def test_cherry_pick_head_after_real_conflicting_cherry_pick(repo: RepoTools):
+    """CHERRY_PICK_HEAD written by a conflicting cherry-pick appears in the graph."""
+    import subprocess
+
+    repo.write("file.txt", "v1")
+    repo.commit("initial")
+    repo.checkout("feature", new=True)
+    repo.write("file.txt", "feature version")
+    feature_sha = repo.commit("feature change")
+    repo.checkout("main")
+    repo.write("file.txt", "main version")
+    repo.commit("main change")
+    try:
+        repo._run(["git", "cherry-pick", feature_sha])
+    except subprocess.CalledProcessError:
+        pass  # conflict is expected
+    assert (repo.path / ".git" / "CHERRY_PICK_HEAD").exists(), (
+        "git cherry-pick should have written CHERRY_PICK_HEAD"
+    )
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert node_in(dg.source, "CHERRY_PICK_HEAD")
+    assert edge_in(dg.source, "CHERRY_PICK_HEAD", feature_sha)
+
+
+def test_cherry_pick_head_absent_no_phantom_node(repo: RepoTools):
+    """When .git/CHERRY_PICK_HEAD doesn't exist, no CHERRY_PICK_HEAD node appears."""
+    repo.write("a.txt")
+    repo.commit("first")
+
+    dg, _, _, _ = _build(str(repo.path), mode="normal")
+    assert "CHERRY_PICK_HEAD" not in dg.source
+
+
+# ---------------------------------------------------------------------------
 # Stash support (issue #7)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -411,17 +411,21 @@ class TestLesson10CherryPick:
 
 
 class TestLesson11Reflog:
-    def test_reset_hard_removes_commit_from_normal_graph(self, repo: RepoTools) -> None:
-        """After reset --hard: the reset-over commit does not appear in the graph."""
+    def test_reset_hard_leaves_orig_head_pointing_at_pre_reset_commit(
+        self, repo: RepoTools
+    ) -> None:
+        """After reset --hard: ORIG_HEAD keeps the pre-reset commit reachable in the graph."""
         repo.write("a.txt")
         sha1 = repo.commit("first")
         repo.write("b.txt")
-        sha2 = repo.commit("second — will be lost")
+        sha2 = repo.commit("second — backed up by ORIG_HEAD")
         repo._run(["git", "reset", "--hard", "HEAD~1"])
         dg, _, _ = _build(str(repo.path))
         src = dg.source
         assert node_in(src, sha1)
-        assert not node_in(src, sha2)
+        # git reset --hard writes ORIG_HEAD, so sha2 stays visible via that ref
+        assert node_in(src, "ORIG_HEAD")
+        assert edge_in(src, "ORIG_HEAD", sha2)
 
     def test_lost_commit_reappears_when_head_detached_at_it(self, repo: RepoTools) -> None:
         """Detaching HEAD at the 'lost' SHA makes it visible again — the object still exists."""


### PR DESCRIPTION
## Summary

- Adds `_read_simple_ref(name)` to `repo.py` — reads `.git/<name>`, validates SHA, confirms object exists; mirrors `_read_fetch_head` but for plain-SHA files
- Wires `ORIG_HEAD`, `MERGE_HEAD`, `CHERRY_PICK_HEAD` into `_collect_refs()` after `FETCH_HEAD`; all appear in normal/verbose/branch modes whenever the corresponding `.git/` file exists
- Updates golden files (the complex e2e repo performs a reset, so `ORIG_HEAD` now appears there)
- Adjusts `TestLesson11Reflog` to reflect the new behavior: `git reset --hard` leaves `ORIG_HEAD` visible in the graph, so the "lost" commit is actually still reachable

## Test plan

- [x] 13 new tests in `test_builder.py`: file-write simulation, real `git reset --hard`, real conflicting merge, real conflicting cherry-pick, absent-file no-phantom, malformed no-crash for each ref
- [x] `ruff check . && ruff format --check .` — clean
- [x] `pytest -v` — 224/224 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)