### PR TITLE
feat #25: annotate branch nodes with worktree path in branch mode

### DIFF
--- a/gitplot/builder.py
+++ b/gitplot/builder.py
@@ -294,6 +294,8 @@ class GraphBuilder:
             label = node.name
             if node.is_head:
                 label = f"HEAD->{node.name}"
+            if node.worktree_path:
+                label = f"{label}\n[wt: {node.worktree_path}]"
             self._add_node(dg, node.name, label=label, type_key=type_key)
 
         # Fork commit nodes -- shown as commit-style nodes labelled with short hash

--- a/gitplot/repo.py
+++ b/gitplot/repo.py
@@ -106,6 +106,7 @@ class BranchNode:
     is_head: bool = False
     is_remote: bool = False
     is_tag: bool = False
+    worktree_path: Optional[str] = None
 
 
 @dataclass
@@ -282,6 +283,8 @@ class GitRepo:
             head_branch = None
             head_commit = None
 
+        worktree_map = self._collect_worktree_map()
+
         for branch in repo.branches:
             try:
                 nodes.append(
@@ -290,6 +293,7 @@ class GitRepo:
                         path=branch.path,
                         commit_hexsha=branch.commit.hexsha,
                         is_head=(head_branch == branch.name),
+                        worktree_path=worktree_map.get(branch.name),
                     )
                 )
             except Exception:
@@ -381,6 +385,36 @@ class GitRepo:
             if len(sha) >= 40 and all(c in "0123456789abcdefABCDEF" for c in sha):
                 entries.append((sha, f"stash@{{{i}}}"))
         return entries
+
+    def _collect_worktree_map(self) -> dict[str, str]:
+        """Return {branch_name: worktree_path} for linked worktrees (excludes the main worktree)."""
+        try:
+            output = self._repo.git.worktree("list", "--porcelain")
+        except Exception:
+            return {}
+
+        # Parse blank-line-separated blocks
+        blocks: list[dict[str, str]] = []
+        current: dict[str, str] = {}
+        for line in output.splitlines():
+            if line == "":
+                if current:
+                    blocks.append(current)
+                    current = {}
+            elif " " in line:
+                key, _, val = line.partition(" ")
+                current[key] = val
+        if current:
+            blocks.append(current)
+
+        # First block is the main worktree — skip it; collect branch->path for the rest
+        result = {}
+        for block in blocks[1:]:
+            path = block.get("worktree", "")
+            branch_ref = block.get("branch", "")
+            if branch_ref.startswith("refs/heads/") and path:
+                result[branch_ref[len("refs/heads/") :]] = path
+        return result
 
     def _collect_refs(self, exclude_remotes: bool, include_stash: bool = False) -> list[RefInfo]:
         """Return refs in traversal order: HEAD, branches, tags, remotes."""

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1143,6 +1143,98 @@ def test_cherry_pick_head_absent_no_phantom_node(repo: RepoTools):
 
 
 # ---------------------------------------------------------------------------
+# Worktree annotation in branch mode (issue #25)
+# ---------------------------------------------------------------------------
+
+
+def test_worktree_no_annotation_when_no_linked_worktrees(repo: RepoTools):
+    """With only the main worktree, no worktree annotation appears in branch mode."""
+    repo.write("a.txt")
+    repo.commit("first")
+
+    dg, _, _, _ = _build(str(repo.path), mode="branch")
+    assert "[wt:" not in dg.source
+
+
+def test_worktree_linked_branch_label_contains_path(repo: RepoTools):
+    """A branch checked out in a linked worktree has its path annotated on the branch node."""
+    repo.write("a.txt")
+    repo.commit("base")
+    repo.checkout("feature", new=True)
+    repo.write("b.txt")
+    repo.commit("feature commit")
+    repo.checkout("main")
+
+    wt_path = repo.path.parent / (repo.path.name + "-wt")
+    repo._run(["git", "worktree", "add", str(wt_path), "feature"])
+
+    dg, _, _, _ = _build(str(repo.path), mode="branch")
+    assert str(wt_path) in dg.source
+
+
+def test_worktree_annotation_on_node_not_separate_node(repo: RepoTools):
+    """Worktree path appears as part of the branch label, not as a separate node."""
+    repo.write("a.txt")
+    repo.commit("base")
+    repo.checkout("feature", new=True)
+    repo.write("b.txt")
+    repo.commit("feature commit")
+    repo.checkout("main")
+
+    wt_path = repo.path.parent / (repo.path.name + "-wt")
+    repo._run(["git", "worktree", "add", str(wt_path), "feature"])
+
+    dg, _, _, _ = _build(str(repo.path), mode="branch")
+    src = dg.source
+    assert str(wt_path) in src
+    assert node_in(src, "feature")
+
+
+def test_worktree_path_populated_on_branch_node(repo: RepoTools):
+    """get_branch_topology() sets worktree_path on the BranchNode for a linked worktree."""
+    from gitplot.repo import GitRepo
+
+    repo.write("a.txt")
+    repo.commit("base")
+    repo.checkout("feature", new=True)
+    repo.write("b.txt")
+    repo.commit("feature commit")
+    repo.checkout("main")
+
+    wt_path = repo.path.parent / (repo.path.name + "-wt")
+    repo._run(["git", "worktree", "add", str(wt_path), "feature"])
+
+    topo = GitRepo(str(repo.path)).get_branch_topology()
+    feature_node = next(n for n in topo.nodes if n.name == "feature")
+    assert feature_node.worktree_path == str(wt_path)
+
+
+def test_worktree_no_path_on_branch_without_worktree(repo: RepoTools):
+    """A branch not checked out in any worktree has worktree_path=None."""
+    from gitplot.repo import GitRepo
+
+    repo.write("a.txt")
+    repo.commit("base")
+    repo.checkout("feature", new=True)
+    repo.write("b.txt")
+    repo.commit("feature commit")
+    repo.checkout("main")
+
+    topo = GitRepo(str(repo.path)).get_branch_topology()
+    feature_node = next(n for n in topo.nodes if n.name == "feature")
+    assert feature_node.worktree_path is None
+
+
+def test_worktree_main_worktree_not_annotated(repo: RepoTools):
+    """The main worktree's branch does not get a worktree annotation (only linked worktrees)."""
+    repo.write("a.txt")
+    repo.commit("first")
+
+    dg, _, _, _ = _build(str(repo.path), mode="branch")
+    assert "[wt:" not in dg.source
+
+
+# ---------------------------------------------------------------------------
 # Stash support (issue #7)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `worktree_path: Optional[str] = None` to `BranchNode` dataclass
- Adds `_collect_worktree_map()` to `GitRepo`: runs `git worktree list --porcelain`, parses blank-line-separated blocks, skips the main worktree entry, returns `{branch_name: worktree_path}` for all linked worktrees
- `get_branch_topology()` now calls `_collect_worktree_map()` and passes the result into each local `BranchNode`
- `builder._build_branch()` appends `\n[wt: <path>]` to the node label when `worktree_path` is set

## Test plan

- [x] `test_worktree_no_annotation_when_no_linked_worktrees` — no `[wt:` in branch mode with no worktrees
- [x] `test_worktree_linked_branch_label_contains_path` — worktree path appears in graph source
- [x] `test_worktree_annotation_on_node_not_separate_node` — path is in label, branch node still exists
- [x] `test_worktree_path_populated_on_branch_node` — `BranchNode.worktree_path` is set correctly
- [x] `test_worktree_no_path_on_branch_without_worktree` — `worktree_path` is `None` for non-worktree branches
- [x] `test_worktree_main_worktree_not_annotated` — main worktree branch is not annotated
- [x] `ruff check . && ruff format --check .` — clean
- [x] `pytest -v` — 230/230 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)