### PR TITLE
fix #36: EP14 remote fork workflow tests + fix repo.remote_refs bug

### DIFF
--- a/gitplot/repo.py
+++ b/gitplot/repo.py
@@ -475,7 +475,7 @@ class GitRepo:
         # Remote refs
         if not exclude_remotes:
             try:
-                for rref in repo.remote_refs:
+                for rref in git.RemoteReference.list_items(repo):
                     if rref.path not in seen:
                         seen.add(rref.path)
                         try:

--- a/tests/golden/shallow_clone_normal.dot
+++ b/tests/golden/shallow_clone_normal.dot
@@ -9,4 +9,8 @@ c61ed" color="0.222 1.000 1.000" fillcolor="0.222 0.100 1.000" penwidth=2 style=
 	c61edbef2405d779b6f3a7bd006e68f095e7ed87 -> "8fb8112ef48db44d2d05e1764e69d43c68e16cf7" [label=parent]
 	"8fb8112ef48db44d2d05e1764e69d43c68e16cf7" [label="commit
 8fb81" color="0.222 1.000 1.000" fillcolor="0.222 0.100 1.000" penwidth=2 style=filled]
+	"refs/remotes/origin/HEAD" [label="origin/HEAD" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	"refs/remotes/origin/HEAD" -> c61edbef2405d779b6f3a7bd006e68f095e7ed87 [label=remote]
+	"refs/remotes/origin/main" [label="origin/main" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	"refs/remotes/origin/main" -> c61edbef2405d779b6f3a7bd006e68f095e7ed87 [label=remote]
 }

--- a/tests/golden/shallow_clone_normal.mermaid
+++ b/tests/golden/shallow_clone_normal.mermaid
@@ -3,10 +3,16 @@ flowchart RL
     refs_heads_main["main"]
     c61edbef2405d779b6f3a7bd006e68f095e7ed87["commit<br/>c61ed"]
     8fb8112ef48db44d2d05e1764e69d43c68e16cf7["commit<br/>8fb81"]
+    refs_remotes_origin_HEAD["origin/HEAD"]
+    refs_remotes_origin_main["origin/main"]
     HEAD --> refs_heads_main
     refs_heads_main --> c61edbef2405d779b6f3a7bd006e68f095e7ed87
     c61edbef2405d779b6f3a7bd006e68f095e7ed87 --> 8fb8112ef48db44d2d05e1764e69d43c68e16cf7
+    refs_remotes_origin_HEAD --> c61edbef2405d779b6f3a7bd006e68f095e7ed87
+    refs_remotes_origin_main --> c61edbef2405d779b6f3a7bd006e68f095e7ed87
     style HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style refs_heads_main fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style c61edbef2405d779b6f3a7bd006e68f095e7ed87 fill:#f6ffe5,stroke:#aaff00,stroke-width:2px
     style 8fb8112ef48db44d2d05e1764e69d43c68e16cf7 fill:#f6ffe5,stroke:#aaff00,stroke-width:2px
+    style refs_remotes_origin_HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
+    style refs_remotes_origin_main fill:#ffe5e5,stroke:#ff0000,stroke-width:2px

--- a/tests/golden/shallow_clone_verbose.dot
+++ b/tests/golden/shallow_clone_verbose.dot
@@ -21,4 +21,8 @@ c61ed" color="0.222 1.000 1.000" fillcolor="0.222 0.100 1.000" penwidth=2 style=
 	c694117fd4e76c22ae04348c15861413019aa03b [label="blob
 c6941" color="0.556 1.000 1.000" fillcolor="0.556 0.100 1.000" penwidth=2 style=filled]
 	"71587d436d19a3bab16924de049d5aba0e7e154c" -> c694117fd4e76c22ae04348c15861413019aa03b [label="file.txt"]
+	"refs/remotes/origin/HEAD" [label="origin/HEAD" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	"refs/remotes/origin/HEAD" -> c61edbef2405d779b6f3a7bd006e68f095e7ed87 [label=remote]
+	"refs/remotes/origin/main" [label="origin/main" color="0.000 1.000 1.000" fillcolor="0.000 0.100 1.000" penwidth=2 style=filled]
+	"refs/remotes/origin/main" -> c61edbef2405d779b6f3a7bd006e68f095e7ed87 [label=remote]
 }

--- a/tests/golden/shallow_clone_verbose.mermaid
+++ b/tests/golden/shallow_clone_verbose.mermaid
@@ -7,6 +7,8 @@ flowchart RL
     8fb8112ef48db44d2d05e1764e69d43c68e16cf7["commit<br/>8fb81"]
     71587d436d19a3bab16924de049d5aba0e7e154c["tree<br/>71587"]
     c694117fd4e76c22ae04348c15861413019aa03b["blob<br/>c6941"]
+    refs_remotes_origin_HEAD["origin/HEAD"]
+    refs_remotes_origin_main["origin/main"]
     HEAD --> refs_heads_main
     refs_heads_main --> c61edbef2405d779b6f3a7bd006e68f095e7ed87
     c61edbef2405d779b6f3a7bd006e68f095e7ed87 --> 54d114dcd54f55e58d8b7dff2a1963d0d807b490
@@ -14,6 +16,8 @@ flowchart RL
     c61edbef2405d779b6f3a7bd006e68f095e7ed87 --> 8fb8112ef48db44d2d05e1764e69d43c68e16cf7
     8fb8112ef48db44d2d05e1764e69d43c68e16cf7 --> 71587d436d19a3bab16924de049d5aba0e7e154c
     71587d436d19a3bab16924de049d5aba0e7e154c -->|"file.txt"| c694117fd4e76c22ae04348c15861413019aa03b
+    refs_remotes_origin_HEAD --> c61edbef2405d779b6f3a7bd006e68f095e7ed87
+    refs_remotes_origin_main --> c61edbef2405d779b6f3a7bd006e68f095e7ed87
     style HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style refs_heads_main fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
     style c61edbef2405d779b6f3a7bd006e68f095e7ed87 fill:#f6ffe5,stroke:#aaff00,stroke-width:2px
@@ -22,3 +26,5 @@ flowchart RL
     style 8fb8112ef48db44d2d05e1764e69d43c68e16cf7 fill:#f6ffe5,stroke:#aaff00,stroke-width:2px
     style 71587d436d19a3bab16924de049d5aba0e7e154c fill:#e5fff6,stroke:#00ffa9,stroke-width:2px
     style c694117fd4e76c22ae04348c15861413019aa03b fill:#e5f6ff,stroke:#00a9ff,stroke-width:2px
+    style refs_remotes_origin_HEAD fill:#ffe5e5,stroke:#ff0000,stroke-width:2px
+    style refs_remotes_origin_main fill:#ffe5e5,stroke:#ff0000,stroke-width:2px

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -13,6 +13,8 @@ Run with:
 
 from __future__ import annotations
 
+import subprocess
+
 from gitplot.builder import GraphBuilder
 from gitplot.repo import GitRepo
 
@@ -36,11 +38,16 @@ def _fork_sha_labels(src: str) -> list[str]:
     return re.findall(r'"?([0-9a-f]{40})"?\s*\[label="fork\n', src)
 
 
-def _build(repo_path: str, mode: str = "normal", **kwargs):
+def _build(
+    repo_path: str,
+    mode: str = "normal",
+    exclude_remotes: bool = False,
+    **kwargs,
+):
     """Build a gitplot graph from a real repo path; return (Digraph, GraphBuilder, RepoGraph)."""
     git_repo = GitRepo(repo_path)
     include_trees = mode == "verbose"
-    graph = git_repo.build_graph(include_trees=include_trees)
+    graph = git_repo.build_graph(include_trees=include_trees, exclude_remotes=exclude_remotes)
     index_state = git_repo.get_index_state() if mode == "verbose" else None
     branch_topo = git_repo.get_branch_topology() if mode == "branch" else None
     builder = GraphBuilder(mode=mode, **kwargs)
@@ -1238,4 +1245,107 @@ class TestLesson12MergeVsRebaseBranchMode:
         # After FF, the two branches are connected by a direct edge (no fork in between)
         assert edge_in(src, "main", "feature") or edge_in(src, "feature", "main"), (
             "After fast-forward merge, main and feature must be directly connected"
+        )
+
+
+# EP 14 — Remote fork workflow
+# Lesson: pushing creates remote tracking refs (refs/remotes/origin/*) that appear
+#         in the graph; local and remote diverge when the local branch advances past
+#         the last push; exclude_remotes hides all remote tracking refs.
+# ---------------------------------------------------------------------------
+
+
+class TestLesson14RemoteFork:
+    def _setup_remote(self, repo: RepoTools) -> None:
+        """Create a bare remote at a sibling directory, add as origin, push main."""
+        remote_path = repo.path.parent / "remote.git"
+        subprocess.check_call(
+            ["git", "init", "--bare", str(remote_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        repo._run(["git", "remote", "add", "origin", str(remote_path)])
+        repo._run(["git", "push", "-u", "origin", "main"])
+
+    def test_remote_tracking_ref_appears_after_push(self, repo: RepoTools) -> None:
+        """After pushing, refs/remotes/origin/main appears as a node pointing at the commit."""
+        repo.write("a.txt")
+        sha1 = repo.commit("initial")
+        self._setup_remote(repo)
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        assert node_in(src, "refs/remotes/origin/main"), (
+            "refs/remotes/origin/main must appear as a node after push"
+        )
+        assert edge_in(src, "refs/remotes/origin/main", sha1), (
+            "refs/remotes/origin/main must edge to the pushed commit SHA"
+        )
+
+    def test_local_and_remote_tracking_ref_diverge_after_local_commit(
+        self, repo: RepoTools
+    ) -> None:
+        """After a local commit past the last push, local and remote diverge."""
+        repo.write("a.txt")
+        sha1 = repo.commit("initial")
+        self._setup_remote(repo)
+
+        repo.write("b.txt")
+        sha2 = repo.commit("local-only")
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        # local branch has advanced to sha2
+        assert edge_in(src, "refs/heads/main", sha2), (
+            "refs/heads/main must point to the new local commit after divergence"
+        )
+        # remote tracking ref still points to the last-pushed commit
+        assert node_in(src, "refs/remotes/origin/main"), (
+            "refs/remotes/origin/main must still appear after local divergence"
+        )
+        assert edge_in(src, "refs/remotes/origin/main", sha1), (
+            "refs/remotes/origin/main must point to the pre-divergence pushed commit"
+        )
+
+    def test_pushed_feature_branch_shows_remote_ref(self, repo: RepoTools) -> None:
+        """After pushing a feature branch, both local and remote tracking refs appear."""
+        repo.write("a.txt")
+        repo.commit("initial")
+        self._setup_remote(repo)
+
+        repo.checkout("feature", new=True)
+        repo.write("feat.txt")
+        sha_feat = repo.commit("feature work")
+        repo._run(["git", "push", "-u", "origin", "feature"])
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        assert node_in(src, "refs/heads/feature"), "Local refs/heads/feature must appear after push"
+        assert node_in(src, "refs/remotes/origin/feature"), (
+            "refs/remotes/origin/feature must appear after push"
+        )
+        assert edge_in(src, "refs/heads/feature", sha_feat), (
+            "Local feature ref must point to the feature commit"
+        )
+        assert edge_in(src, "refs/remotes/origin/feature", sha_feat), (
+            "Remote tracking ref must point to the same feature commit"
+        )
+
+    def test_remote_refs_hidden_with_exclude_remotes(self, repo: RepoTools) -> None:
+        """With exclude_remotes=True, no refs/remotes/* nodes appear; local refs survive."""
+        repo.write("a.txt")
+        repo.commit("initial")
+        self._setup_remote(repo)
+
+        dg, _, _ = _build(str(repo.path), exclude_remotes=True)
+        src = dg.source
+
+        assert "refs/remotes" not in src, (
+            "With exclude_remotes=True, no refs/remotes/* nodes should appear"
+        )
+        assert node_in(src, "refs/heads/main"), (
+            "Local refs/heads/main must still appear when remotes are excluded"
         )

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -1257,8 +1257,8 @@ class TestLesson12MergeVsRebaseBranchMode:
 
 class TestLesson14RemoteFork:
     def _setup_remote(self, repo: RepoTools) -> None:
-        """Create a bare remote at a sibling directory, add as origin, push main."""
-        remote_path = repo.path.parent / "remote.git"
+        """Create a bare remote unique to this test's tmp dir, add as origin, push main."""
+        remote_path = repo.path.parent / (repo.path.name + "_remote.git")
         subprocess.check_call(
             ["git", "init", "--bare", str(remote_path)],
             stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
- Fixed `repo.remote_refs` (non-existent GitPython attribute silently swallowed by `except Exception`) — replaced with `git.RemoteReference.list_items(repo)`, so remote tracking refs now actually appear in the graph
- Added `TestLesson14RemoteFork` (4 tests): push creates `refs/remotes/origin/*` node; local/remote diverge after local commit; pushed feature branch shows both local and remote refs; `exclude_remotes=True` hides all `refs/remotes/*` nodes
- Updated `_build()` helper to accept `exclude_remotes` kwarg and pass it through to `build_graph()`
- Regenerated 4 shallow clone golden files to include the previously-missing `origin/main` and `origin/HEAD` remote tracking refs

## Test plan
- [ ] `pytest tests/test_lessons.py::TestLesson14RemoteFork -v` — all 4 tests pass
- [ ] `pytest -q` — full suite 251/251 pass
- [ ] `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)