### PR TITLE
feat #37: surface BISECT_HEAD in graph + EP15 bisect lesson tests

### DIFF
--- a/gitplot/repo.py
+++ b/gitplot/repo.py
@@ -504,8 +504,8 @@ class GitRepo:
                 )
             )
 
-        # ORIG_HEAD / MERGE_HEAD / CHERRY_PICK_HEAD — written during resets, merges, cherry-picks
-        for special_name in ("ORIG_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD"):
+        # ORIG_HEAD / MERGE_HEAD / CHERRY_PICK_HEAD / BISECT_HEAD
+        for special_name in ("ORIG_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD", "BISECT_HEAD"):
             sp_sha = self._read_simple_ref(special_name)
             if sp_sha and special_name not in seen:
                 seen.add(special_name)

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -1349,3 +1349,81 @@ class TestLesson14RemoteFork:
         assert node_in(src, "refs/heads/main"), (
             "Local refs/heads/main must still appear when remotes are excluded"
         )
+
+
+# EP 15 — git bisect and the Commit Graph
+# Lesson: during an active bisect session git writes .git/BISECT_HEAD pointing
+#         at the commit currently under test; gitplot surfaces it as a ref node
+#         so learners can see exactly where bisect has landed in the history.
+# ---------------------------------------------------------------------------
+
+
+class TestLesson15Bisect:
+    def _linear_repo(self, repo: RepoTools) -> tuple[str, str, str]:
+        """Three-commit linear history: sha1 (good) < sha2 (midpoint) < sha3 (bad)."""
+        repo.write("a.txt")
+        sha1 = repo.commit("first")
+        repo.write("b.txt")
+        sha2 = repo.commit("second")
+        repo.write("c.txt")
+        sha3 = repo.commit("third")
+        return sha1, sha2, sha3
+
+    def test_bisect_head_appears_during_bisect_session(self, repo: RepoTools) -> None:
+        """After git bisect start --no-checkout + marking good/bad, BISECT_HEAD appears."""
+        sha1, sha2, sha3 = self._linear_repo(repo)
+        repo._run(["git", "bisect", "start", "--no-checkout"])
+        repo._run(["git", "bisect", "bad", sha3])
+        repo._run(["git", "bisect", "good", sha1])
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        assert node_in(src, "BISECT_HEAD"), (
+            "BISECT_HEAD must appear as a ref node during an active bisect session"
+        )
+        assert edge_in(src, "BISECT_HEAD", sha2), (
+            "BISECT_HEAD must edge to the midpoint commit git bisect selected"
+        )
+
+    def test_bisect_head_absent_when_not_bisecting(self, repo: RepoTools) -> None:
+        """Without an active bisect session, no BISECT_HEAD node appears."""
+        self._linear_repo(repo)
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        assert not node_in(src, "BISECT_HEAD"), (
+            "BISECT_HEAD must not appear when no bisect session is in progress"
+        )
+
+    def test_bisect_head_malformed_does_not_crash(self, repo: RepoTools) -> None:
+        """A garbage .git/BISECT_HEAD file is silently ignored; no phantom node."""
+        self._linear_repo(repo)
+        (repo.path / ".git" / "BISECT_HEAD").write_text("not-a-valid-sha\n", encoding="utf-8")
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        assert not node_in(src, "BISECT_HEAD"), (
+            "A malformed BISECT_HEAD file must be silently ignored -- no phantom node"
+        )
+
+    def test_bisect_good_bad_marks_visible_alongside_bisect_head(self, repo: RepoTools) -> None:
+        """In --no-checkout mode HEAD stays on main while BISECT_HEAD marks the midpoint."""
+        sha1, sha2, sha3 = self._linear_repo(repo)
+        repo._run(["git", "bisect", "start", "--no-checkout"])
+        repo._run(["git", "bisect", "bad", sha3])
+        repo._run(["git", "bisect", "good", sha1])
+
+        dg, _, _ = _build(str(repo.path))
+        src = dg.source
+
+        assert node_in(src, "BISECT_HEAD"), "BISECT_HEAD must appear"
+        assert node_in(src, "refs/heads/main"), "main branch ref must still appear"
+        assert edge_in(src, "refs/heads/main", sha3), (
+            "main must still point at sha3 -- HEAD did not move in --no-checkout mode"
+        )
+        assert edge_in(src, "BISECT_HEAD", sha2), (
+            "BISECT_HEAD must point at the midpoint between good sha1 and bad sha3"
+        )


### PR DESCRIPTION
## Summary
- Added `"BISECT_HEAD"` to the special-ref tuple in `_collect_refs` — one-line production change
- `_read_simple_ref` already handles the file format; no other production changes needed
- Added `TestLesson15Bisect` (4 tests) covering: BISECT_HEAD node + edge to midpoint during active bisect; absent when not bisecting; malformed file silently ignored; main stays on bad commit while BISECT_HEAD marks the midpoint in `--no-checkout` mode

## How BISECT_HEAD works
`git bisect start --no-checkout` writes `.git/BISECT_HEAD` pointing at the commit to test instead of checking out. This lets tests observe BISECT_HEAD without moving HEAD around.

## Test plan
- [ ] `pytest tests/test_lessons.py::TestLesson15Bisect -v` — 4/4 pass
- [ ] `pytest -q` — full suite 255/255 pass
- [ ] `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)