### PR TITLE
feat #38: handle gitlink entries in verbose mode + EP16 submodule lesson tests

### DIFF
--- a/gitplot/builder.py
+++ b/gitplot/builder.py
@@ -245,6 +245,11 @@ class GraphBuilder:
             self._add_node(dg, blob_hexsha, label=f"blob\n{blob_hexsha[:hl]}", type_key="blob")
             self._add_edge(dg, tree_hexsha, blob_hexsha, label=name)
 
+        for name, commit_hexsha in td.gitlink_entries:
+            node_id = f"gitlink|{commit_hexsha}"
+            self._add_node(dg, node_id, label=f"gitlink\n{commit_hexsha[:hl]}", type_key="blob")
+            self._add_edge(dg, tree_hexsha, node_id, label=name)
+
         for child_tree_hexsha in td.child_tree_hexshas:
             self._add_tree_recursive(dg, graph, child_tree_hexsha, tree_hexsha, hl)
 

--- a/gitplot/repo.py
+++ b/gitplot/repo.py
@@ -68,6 +68,7 @@ class TreeData:
     parent_hexsha: str  # parent commit or tree hexsha
     child_tree_hexshas: list[str] = field(default_factory=list)
     blob_entries: list[tuple[str, str]] = field(default_factory=list)  # (name, hexsha)
+    gitlink_entries: list[tuple[str, str]] = field(default_factory=list)  # (name, commit_hexsha)
 
 
 @dataclass
@@ -680,6 +681,7 @@ class GitRepo:
             parent_hexsha=parent_hexsha,
             child_tree_hexshas=[t.hexsha for t in tree.trees],
             blob_entries=[(b.name, b.hexsha) for b in tree.blobs],
+            gitlink_entries=[(s.path, s.hexsha) for s in tree if s.mode == 0o160000],
         )
 
         for blob in tree.blobs:

--- a/tests/test_lessons.py
+++ b/tests/test_lessons.py
@@ -1427,3 +1427,110 @@ class TestLesson15Bisect:
         assert edge_in(src, "BISECT_HEAD", sha2), (
             "BISECT_HEAD must point at the midpoint between good sha1 and bad sha3"
         )
+
+
+# EP 16 — git submodules (gitlink entries in verbose mode)
+# Lesson: a submodule is stored as a mode-160000 gitlink entry in the parent tree.
+#         In verbose mode gitplot must render gitlink entries as distinct nodes
+#         (not blobs) so learners can see the pointer into the submodule's history.
+# ---------------------------------------------------------------------------
+
+
+class TestLesson16Submodules:
+    def _setup_with_submodule(self, repo: RepoTools) -> tuple[str, str]:
+        """Create a bare-enough subrepo, add it as a submodule, commit.
+
+        Returns (tree_sha, sub_commit_sha) — the root tree of the parent commit
+        and the commit SHA the gitlink points at.
+        """
+        sub_path = repo.path.parent / (repo.path.name + "_sub")
+        subprocess.check_call(
+            ["git", "init", "-b", "main", str(sub_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.check_call(
+            ["git", "config", "user.email", "sub@test"], cwd=sub_path, stderr=subprocess.DEVNULL
+        )
+        subprocess.check_call(
+            ["git", "config", "user.name", "Sub"], cwd=sub_path, stderr=subprocess.DEVNULL
+        )
+        (sub_path / "sub.txt").write_text("sub content", encoding="utf-8")
+        subprocess.check_call(["git", "add", "-A"], cwd=sub_path, stderr=subprocess.DEVNULL)
+        subprocess.check_call(
+            ["git", "commit", "-m", "sub init"], cwd=sub_path, stderr=subprocess.DEVNULL
+        )
+        sub_commit_sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=sub_path, stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+
+        # Stage a regular file, add the submodule, then commit everything together
+        repo.write("main.txt")
+        repo._run(["git", "add", "main.txt"])
+        repo._run(
+            [
+                "git",
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                sub_path.as_posix(),
+                "lib",
+            ]
+        )
+        repo._run(["git", "commit", "-m", "add submodule"])
+        tree_sha = repo._run(["git", "rev-parse", "HEAD^{tree}"])
+
+        return tree_sha, sub_commit_sha
+
+    def test_submodule_gitlink_does_not_crash_verbose_build(self, repo: RepoTools) -> None:
+        """Verbose build on a repo with a submodule must not raise."""
+        self._setup_with_submodule(repo)
+
+        dg, _, _ = _build(str(repo.path), mode="verbose")
+        src = dg.source
+
+        assert node_in(src, "HEAD")
+        assert node_in(src, "refs/heads/main")
+
+    def test_gitlink_entry_appears_as_distinct_node_in_verbose_mode(self, repo: RepoTools) -> None:
+        """The submodule tree entry appears as a gitlink node, not a blob."""
+        _, sub_commit_sha = self._setup_with_submodule(repo)
+
+        dg, _, _ = _build(str(repo.path), mode="verbose")
+        src = dg.source
+
+        gitlink_node_id = f"gitlink|{sub_commit_sha}"
+        assert node_in(src, gitlink_node_id), (
+            "Submodule entry must appear as a gitlink node with ID gitlink|<sha>"
+        )
+        assert '"gitlink\n' in src, (
+            "Gitlink node label must start with 'gitlink' to distinguish it from blobs"
+        )
+
+    def test_gitlink_edge_from_tree_to_submodule_node(self, repo: RepoTools) -> None:
+        """The parent tree must have an edge to the gitlink node."""
+        tree_sha, sub_commit_sha = self._setup_with_submodule(repo)
+
+        dg, _, _ = _build(str(repo.path), mode="verbose")
+        src = dg.source
+
+        gitlink_node_id = f"gitlink|{sub_commit_sha}"
+        assert edge_in(src, tree_sha, gitlink_node_id), (
+            "Root tree node must have an edge to the gitlink node"
+        )
+
+    def test_non_submodule_blobs_still_render_alongside_gitlink(self, repo: RepoTools) -> None:
+        """Regular blobs in the same commit still appear correctly alongside the gitlink."""
+        _, sub_commit_sha = self._setup_with_submodule(repo)
+
+        dg, _, _ = _build(str(repo.path), mode="verbose")
+        src = dg.source
+
+        gitlink_node_id = f"gitlink|{sub_commit_sha}"
+        assert node_in(src, gitlink_node_id), "Gitlink node must appear"
+        assert '"blob\n' in src, "Regular blob nodes must still appear alongside the gitlink node"


### PR DESCRIPTION
## Summary
- Added `gitlink_entries: list[tuple[str, str]]` to `TreeData` to hold mode-160000 tree entries
- Fixed collection: `tree.submodules` doesn't exist in GitPython 3.1.x — instead iterate the tree object and filter by `item.mode == 0o160000`; use `item.path` not `item.name` (which throws `AttributeError` on uninitialized Submodule objects)
- Builder renders gitlink entries as `"gitlink|<commit_sha>"` nodes with label `gitlink\n<short_sha>`, connected from the parent tree node
- Added `TestLesson16Submodules` (4 tests): no-crash in verbose mode; gitlink node appears with correct ID; tree has edge to gitlink; regular blobs still render alongside

## Gotchas discovered
- `git submodule add` requires `-c protocol.file.allow=always` on newer git (file transport disabled by default)
- `git rev-parse HEAD^{tree}` (not `git commit` stdout) is needed to get the tree SHA reliably

## Test plan
- [ ] `pytest tests/test_lessons.py::TestLesson16Submodules -v` — 4/4 pass
- [ ] `pytest -q` — full suite 259/259 pass
- [ ] `ruff check . && ruff format --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)