### PR TITLE
ci: add PyPI publish job; bump version to 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,56 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  publish:
+    name: publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [checks, test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write  # needed to push the version tag
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch full history so we can check existing tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version tag already exists
+        id: tag_check
+        run: |
+          if git rev-parse --verify "refs/tags/${{ steps.version.outputs.tag }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ steps.version.outputs.tag }} already exists — skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build wheel and sdist
+        if: steps.tag_check.outputs.exists == 'false'
+        run: pip install build && python -m build
+
+      - name: Publish to PyPI
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create and push version tag
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gitplot"
-version = "0.2.0"
+version = "0.3.0"
 description = "Graphviz visualizations of git repository structure"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Adds a `publish` job to `.github/workflows/ci.yml` that runs automatically on every push to `main`
- Bumps version to `0.3.0` for the first automated release

## How it works

```
push to main
  └── checks (lint, format, CRLF, file sizes)
  └── test (ubuntu + windows × py3.9 + py3.12 + py3.14)
        └── publish (only after all checks + tests pass)
              ├── read version from pyproject.toml
              ├── skip if git tag v<version> already exists (idempotent)
              ├── build wheel + sdist
              ├── publish to PyPI via PYPI_API_TOKEN secret
              └── create + push git tag
```

## Prerequisite (one-time setup)

Add `PYPI_API_TOKEN` as a repository secret:  
GitHub repo → Settings → Secrets and variables → Actions → New repository secret

## Test plan
- [ ] CI passes on this PR (checks + test matrix — publish job skips because this is not a push to main)
- [ ] After squash-merge to develop → merge to main: publish job should fire, create `v0.3.0` tag, and publish to PyPI

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)