### PR TITLE
fix #63: shorten all 39 YouTube titles for search truncation and keyword front-loading

### DIFF
--- a/docs/curriculum/00-setup.md
+++ b/docs/curriculum/00-setup.md
@@ -17,7 +17,7 @@
 Most git tutorials describe commands in words; this series shows you the actual data structure git is manipulating underneath every command — a DAG of commit objects plus a handful of pointers. Setting up a live-updating diagram alongside your terminal is the foundation the whole series relies on: once you can see the graph change in real time, every later episode becomes a direct observation instead of an act of faith in what the manual says.
 
 #### YouTube Title
-> See Your Git: Live Repository Diagrams That Update as You Type Commands
+> Visualize Git Commits Live: Setup in 5 Minutes
 
 #### YouTube Description
 > Stop guessing what git commands do — watch them happen. This video sets up visigit, a free tool that turns any git repository into a live diagram. Every command you run updates the graph in real time. Install it in under five minutes and you'll never memorize git blindly again.

--- a/docs/curriculum/01-beginner.md
+++ b/docs/curriculum/01-beginner.md
@@ -17,7 +17,7 @@
 git's data model is deceptively simple: a commit is a snapshot with a pointer to its parent, a branch is a movable label pointing at a commit, and HEAD is a label pointing at whichever branch (or commit) you're standing on. Every other git command in this series is just a variation on moving or creating these three kinds of pointers. Understanding this three-tier structure from the very first commit is what makes reset, rebase, and detached HEAD make sense later instead of feeling like separate tricks to memorize.
 
 #### YouTube Title
-> git init, add, commit — Watch the Commit Graph Build Itself in Real Time
+> git init, add, commit: Watch the Commit Graph Build Live
 
 #### YouTube Description
 > You've run git init and git commit a hundred times. But do you know what they actually create? This video uses visigit to show you the moment HEAD, a branch ref, and your first commit node appear in the graph — and how the chain grows with every new commit. By the end you'll understand exactly what git status and git log are reporting.
@@ -57,7 +57,7 @@ git's data model is deceptively simple: a commit is a snapshot with a pointer to
 Git tracks files it already knows about and reports everything else as untracked — .gitignore only controls which NEW files get offered up for tracking; it has no opinion about files git has already committed. This is the single most common .gitignore misunderstanding, and it matters because people routinely assume adding a file to .gitignore will make a secret or a build artifact "go away," when it actually does nothing until you explicitly untrack it with git rm --cached.
 
 #### YouTube Title
-> .gitignore Doesn't Untrack Files — Here's What It Actually Does (and What git clean Does Instead)
+> .gitignore Doesn't Untrack Files (Here's What Does)
 
 #### YouTube Description
 > Everyone's first .gitignore mistake is the same: adding a file to it and expecting git to stop tracking it. .gitignore only stops NEW files from being tracked — it has zero effect on files git already knows about. This video uses visigit's verbose-mode Untracked box to show exactly what .gitignore prevents, what git rm --cached does to actually untrack a file, and what git clean deletes that .gitignore doesn't.
@@ -100,7 +100,7 @@ Git tracks files it already knows about and reports everything else as untracked
 A branch is not a copy of your code — it's a pointer to a single commit, which is why creating one is instant regardless of repository size. The entire concept of "lightweight branching" that makes git workflows fast and cheap depends on this fact, and once you've seen a branch created as nothing but a new label on an existing commit, phrases like "check out a branch" stop sounding like file operations and start sounding like what they are: pointer moves.
 
 #### YouTube Title
-> git branch Doesn't Copy Anything — Here's What It Actually Does to Your Repository
+> git branch Doesn't Copy Your Code — Here's What It Does
 
 #### YouTube Description
 > Most people think creating a branch copies their code. It doesn't — it creates a single pointer to an existing commit. Watch visigit show you the exact moment a branch label appears in the graph and how it splits from its sibling when you make your first commit. This one diagram will change how you think about branches forever.
@@ -139,7 +139,7 @@ A branch is not a copy of your code — it's a pointer to a single commit, which
 "Merge" is really two different operations wearing one name: a fast-forward, which just slides a pointer forward with no new commit, and a true merge, which creates a new commit with two parents. Knowing which one you're about to get — and that --no-ff can force the second even when the first would work — is the difference between a history that shows exactly when features were integrated and one that quietly erases that information.
 
 #### YouTube Title
-> git merge --no-ff Creates a Diamond — Here's What That Means and Why It Matters
+> git merge --no-ff: Why It Creates a Diamond in Your History
 
 #### YouTube Description
 > There are two completely different graph shapes that can result from a merge: a straight line (fast-forward) or a diamond (no-fast-forward). This video shows both side by side in visigit so you can see exactly when git moves a pointer vs when it creates a real merge commit — and why that choice affects your project history permanently.
@@ -179,7 +179,7 @@ A branch is not a copy of your code — it's a pointer to a single commit, which
 A merge conflict isn't git being broken, it's git being honest that it can't guess which change you want — and it pauses by writing MERGE_HEAD, a real ref pointing at the commit you're merging in, so both you and git can keep track of what's being combined. Understanding that MERGE_HEAD is just an ordinary pointer, not a special error state, is what turns "I'm scared of conflicts" into "I know exactly what git is waiting on me to do."
 
 #### YouTube Title
-> Merge Conflicts Aren't Scary: git Writes MERGE_HEAD and visigit Shows You Exactly Where You Are
+> Resolving a Git Merge Conflict: What MERGE_HEAD Shows You
 
 #### YouTube Description
 > A merge conflict stops git mid-merge and leaves you in a state most people find terrifying. It shouldn't be. When a merge conflicts, git writes a ref called MERGE_HEAD pointing at the commit you're merging in — and visigit shows it right in the graph, so you can always see both sides of the merge and exactly what you're resolving. This video walks a conflict from start to finish: what MERGE_HEAD is, how to resolve it, and how to bail out with --abort.
@@ -218,7 +218,7 @@ A merge conflict isn't git being broken, it's git being honest that it can't gue
 All three flavors of git reset do the exact same first step — move the current branch's pointer to a different commit — and only differ in how much of the index and working tree they drag along with it. Once you see that --soft, --mixed, and --hard are one operation with three levels of "and also," reset stops being three commands to memorize and becomes one mental model with a dial on it.
 
 #### YouTube Title
-> git reset --soft vs --mixed vs --hard: Watch the Branch Pointer Move Three Different Ways
+> git reset --soft vs --mixed vs --hard Explained
 
 #### YouTube Description
 > git reset is one of the most feared commands in git — and the most misunderstood. All three modes do the same thing to the branch pointer (move it back), so in normal mode they produce an identical graph; what they differ on is how much of your work they preserve, which you see in verbose mode. And the commit you reset past does not vanish — ORIG_HEAD still points to it. Watch visigit show you all of this, and you'll never confuse the three modes again.
@@ -258,7 +258,7 @@ All three flavors of git reset do the exact same first step — move the current
 git doesn't have one "undo," it has three, and they do fundamentally different things to history: revert adds a new commit, amend replaces the last commit with a new one, and reset moves the pointer without changing any commit's content. Picking the wrong one is exactly how people rewrite history they've already shared with a team — this episode exists so "how do I undo this" always leads to the right tool instead of a reflexive git reset --hard.
 
 #### YouTube Title
-> git revert vs git commit --amend vs git reset: Three Ways to Undo, Three Different Graphs
+> git revert vs amend vs reset: 3 Ways to Undo in Git
 
 #### YouTube Description
 > "Undo" in git isn't one thing. revert ADDS a new commit that cancels an old one (safe to share). amend REWRITES your last commit (new SHA, the old one orphaned). reset MOVES the branch pointer back. They look similar in the terminal but do completely different things to the graph — and visigit makes the difference impossible to miss. By the end you'll always pick the right one.
@@ -298,7 +298,7 @@ git doesn't have one "undo," it has three, and they do fundamentally different t
 HEAD is normally two hops from a commit — HEAD points at a branch, and the branch points at the commit — but git also allows HEAD to point directly at a commit, skipping the branch entirely. That's all "detached HEAD" is: a missing middle link, not a broken repository. Knowing this means the scariest sentence in git's output ("you are in 'detached HEAD' state") becomes a state you can calmly read off the graph and walk out of.
 
 #### YouTube Title
-> "You are in 'detached HEAD' state" — What It Means and How to Escape
+> Detached HEAD in Git: What It Means and How to Escape
 
 #### YouTube Description
 > "You are in 'detached HEAD' state" is one of the most alarming messages in git. But it's not dangerous — it just means HEAD is pointing directly at a commit instead of through a branch. Watch visigit show you exactly what detached HEAD looks like in the graph, what happens to commits you make in that state, and the two ways to safely get back.
@@ -337,7 +337,7 @@ HEAD is normally two hops from a commit — HEAD points at a branch, and the bra
 Every commit in this series so far has had a parent — but git doesn't require that, and --orphan is how you deliberately create another commit with zero parents inside a repo that already has history. This is exactly the mechanism behind real-world patterns like a gh-pages branch living beside your source code with no shared history at all, and seeing it happen on purpose demystifies what would otherwise look like a broken or corrupted graph.
 
 #### YouTube Title
-> git checkout --orphan: Two Branches, One Repo, Zero Shared History
+> git checkout --orphan: Branches With Zero Shared History
 
 #### YouTube Description
 > Every commit you've made in this series so far has had a parent — except the very first. git checkout --orphan lets you deliberately create ANOTHER parentless commit, on a brand-new branch, inside a repo that already has history. That's exactly how gh-pages branches and "start clean" branches work. This video shows the disconnected commit forming live in visigit, and proves with git merge-base that it truly shares nothing with main.

--- a/docs/curriculum/01-beginner.md
+++ b/docs/curriculum/01-beginner.md
@@ -57,7 +57,7 @@ git's data model is deceptively simple: a commit is a snapshot with a pointer to
 Git tracks files it already knows about and reports everything else as untracked — .gitignore only controls which NEW files get offered up for tracking; it has no opinion about files git has already committed. This is the single most common .gitignore misunderstanding, and it matters because people routinely assume adding a file to .gitignore will make a secret or a build artifact "go away," when it actually does nothing until you explicitly untrack it with git rm --cached.
 
 #### YouTube Title
-> .gitignore Doesn't Untrack Files (Here's What Does)
+> .gitignore Doesn't Untrack Files (Watch What Does)
 
 #### YouTube Description
 > Everyone's first .gitignore mistake is the same: adding a file to it and expecting git to stop tracking it. .gitignore only stops NEW files from being tracked — it has zero effect on files git already knows about. This video uses visigit's verbose-mode Untracked box to show exactly what .gitignore prevents, what git rm --cached does to actually untrack a file, and what git clean deletes that .gitignore doesn't.
@@ -100,7 +100,7 @@ Git tracks files it already knows about and reports everything else as untracked
 A branch is not a copy of your code — it's a pointer to a single commit, which is why creating one is instant regardless of repository size. The entire concept of "lightweight branching" that makes git workflows fast and cheap depends on this fact, and once you've seen a branch created as nothing but a new label on an existing commit, phrases like "check out a branch" stop sounding like file operations and start sounding like what they are: pointer moves.
 
 #### YouTube Title
-> git branch Doesn't Copy Your Code — Here's What It Does
+> git branch Doesn't Copy Your Code — Watch What It Does
 
 #### YouTube Description
 > Most people think creating a branch copies their code. It doesn't — it creates a single pointer to an existing commit. Watch visigit show you the exact moment a branch label appears in the graph and how it splits from its sibling when you make your first commit. This one diagram will change how you think about branches forever.
@@ -139,7 +139,7 @@ A branch is not a copy of your code — it's a pointer to a single commit, which
 "Merge" is really two different operations wearing one name: a fast-forward, which just slides a pointer forward with no new commit, and a true merge, which creates a new commit with two parents. Knowing which one you're about to get — and that --no-ff can force the second even when the first would work — is the difference between a history that shows exactly when features were integrated and one that quietly erases that information.
 
 #### YouTube Title
-> git merge --no-ff: Why It Creates a Diamond in Your History
+> git merge --no-ff: See the Diamond It Creates
 
 #### YouTube Description
 > There are two completely different graph shapes that can result from a merge: a straight line (fast-forward) or a diamond (no-fast-forward). This video shows both side by side in visigit so you can see exactly when git moves a pointer vs when it creates a real merge commit — and why that choice affects your project history permanently.
@@ -179,7 +179,7 @@ A branch is not a copy of your code — it's a pointer to a single commit, which
 A merge conflict isn't git being broken, it's git being honest that it can't guess which change you want — and it pauses by writing MERGE_HEAD, a real ref pointing at the commit you're merging in, so both you and git can keep track of what's being combined. Understanding that MERGE_HEAD is just an ordinary pointer, not a special error state, is what turns "I'm scared of conflicts" into "I know exactly what git is waiting on me to do."
 
 #### YouTube Title
-> Resolving a Git Merge Conflict: What MERGE_HEAD Shows You
+> Resolving a Git Merge Conflict: Watch MERGE_HEAD Appear
 
 #### YouTube Description
 > A merge conflict stops git mid-merge and leaves you in a state most people find terrifying. It shouldn't be. When a merge conflicts, git writes a ref called MERGE_HEAD pointing at the commit you're merging in — and visigit shows it right in the graph, so you can always see both sides of the merge and exactly what you're resolving. This video walks a conflict from start to finish: what MERGE_HEAD is, how to resolve it, and how to bail out with --abort.
@@ -218,7 +218,7 @@ A merge conflict isn't git being broken, it's git being honest that it can't gue
 All three flavors of git reset do the exact same first step — move the current branch's pointer to a different commit — and only differ in how much of the index and working tree they drag along with it. Once you see that --soft, --mixed, and --hard are one operation with three levels of "and also," reset stops being three commands to memorize and becomes one mental model with a dial on it.
 
 #### YouTube Title
-> git reset --soft vs --mixed vs --hard Explained
+> git reset --soft vs --mixed vs --hard, Visualized
 
 #### YouTube Description
 > git reset is one of the most feared commands in git — and the most misunderstood. All three modes do the same thing to the branch pointer (move it back), so in normal mode they produce an identical graph; what they differ on is how much of your work they preserve, which you see in verbose mode. And the commit you reset past does not vanish — ORIG_HEAD still points to it. Watch visigit show you all of this, and you'll never confuse the three modes again.
@@ -258,7 +258,7 @@ All three flavors of git reset do the exact same first step — move the current
 git doesn't have one "undo," it has three, and they do fundamentally different things to history: revert adds a new commit, amend replaces the last commit with a new one, and reset moves the pointer without changing any commit's content. Picking the wrong one is exactly how people rewrite history they've already shared with a team — this episode exists so "how do I undo this" always leads to the right tool instead of a reflexive git reset --hard.
 
 #### YouTube Title
-> git revert vs amend vs reset: 3 Ways to Undo in Git
+> git revert vs amend vs reset: Watch 3 Ways to Undo
 
 #### YouTube Description
 > "Undo" in git isn't one thing. revert ADDS a new commit that cancels an old one (safe to share). amend REWRITES your last commit (new SHA, the old one orphaned). reset MOVES the branch pointer back. They look similar in the terminal but do completely different things to the graph — and visigit makes the difference impossible to miss. By the end you'll always pick the right one.
@@ -298,7 +298,7 @@ git doesn't have one "undo," it has three, and they do fundamentally different t
 HEAD is normally two hops from a commit — HEAD points at a branch, and the branch points at the commit — but git also allows HEAD to point directly at a commit, skipping the branch entirely. That's all "detached HEAD" is: a missing middle link, not a broken repository. Knowing this means the scariest sentence in git's output ("you are in 'detached HEAD' state") becomes a state you can calmly read off the graph and walk out of.
 
 #### YouTube Title
-> Detached HEAD in Git: What It Means and How to Escape
+> Detached HEAD in Git: Watch What It Means, How to Escape
 
 #### YouTube Description
 > "You are in 'detached HEAD' state" is one of the most alarming messages in git. But it's not dangerous — it just means HEAD is pointing directly at a commit instead of through a branch. Watch visigit show you exactly what detached HEAD looks like in the graph, what happens to commits you make in that state, and the two ways to safely get back.
@@ -337,7 +337,7 @@ HEAD is normally two hops from a commit — HEAD points at a branch, and the bra
 Every commit in this series so far has had a parent — but git doesn't require that, and --orphan is how you deliberately create another commit with zero parents inside a repo that already has history. This is exactly the mechanism behind real-world patterns like a gh-pages branch living beside your source code with no shared history at all, and seeing it happen on purpose demystifies what would otherwise look like a broken or corrupted graph.
 
 #### YouTube Title
-> git checkout --orphan: Branches With Zero Shared History
+> git checkout --orphan: See Zero Shared History
 
 #### YouTube Description
 > Every commit you've made in this series so far has had a parent — except the very first. git checkout --orphan lets you deliberately create ANOTHER parentless commit, on a brand-new branch, inside a repo that already has history. That's exactly how gh-pages branches and "start clean" branches work. This video shows the disconnected commit forming live in visigit, and proves with git merge-base that it truly shares nothing with main.

--- a/docs/curriculum/02-intermediate.md
+++ b/docs/curriculum/02-intermediate.md
@@ -17,7 +17,7 @@
 Merge and rebase solve the identical problem — integrating diverged work — with opposite philosophies: merge preserves exactly what happened (including the diamond shape), while rebase rewrites what happened into a story that never diverged in the first place. Neither is "correct"; they're a tradeoff between historical honesty and readability, and the rest of the advanced tier (interactive rebase, --onto, rerere) only makes sense once this tradeoff is clear.
 
 #### YouTube Title
-> git merge vs git rebase: Same Result, Different History
+> git merge vs git rebase: Watch Two Different Graphs
 
 #### YouTube Description
 > Merge and rebase both get your changes integrated, but they leave completely different histories behind. This video runs both operations on identical repos and shows you the graphs side by side: a merge creates a diamond with a merge commit; a rebase replays your commits with new SHAs onto a straight line. By the end you'll know which to choose and why.
@@ -57,7 +57,7 @@ Merge and rebase solve the identical problem — integrating diverged work — w
 Because rebase replays your commits one at a time instead of integrating them all at once like a merge, a single line of disputed code can produce a conflict on every commit that touches it — which is why rebase conflicts feel repetitive in a way merge conflicts don't. Understanding that each replay is its own mini-merge is what turns "why do I keep hitting the same conflict" into an expected, manageable part of the process instead of a sign something's gone wrong.
 
 #### YouTube Title
-> git rebase Conflicts: Why They Repeat and How to Fix Them
+> git rebase Conflicts: Watch Why They Keep Repeating
 
 #### YouTube Description
 > A merge conflict stops you once. A rebase conflict can stop you once PER COMMIT being replayed, because rebase applies your commits one at a time. This video walks a real two-commit rebase conflict start to finish — resolving, continuing, resolving again — and shows the three escape hatches: --continue, --skip, and --abort. You'll see exactly why the same conflict can reappear and what visigit shows you while it's happening.
@@ -100,7 +100,7 @@ Because rebase replays your commits one at a time instead of integrating them al
 Your local main and origin/main are two separate, independently-moving pointers, and the second one is nothing but a cached snapshot of what the remote looked like at your last fetch — it does not update itself. This distinction is the root of most "but I thought I had the latest code" confusion, and once origin/* refs are visibly separate objects in the graph instead of an abstract idea, fetch/pull/push stop being magic syncing and become exactly what they are: explicit pointer updates you control.
 
 #### YouTube Title
-> origin/main Is Not main: How fetch, pull, and push Work
+> origin/main Is Not main: Watch fetch, pull, push Work
 
 #### YouTube Description
 > There are actually two "main" branches in a typical repo: your local main and origin/main (the remote tracking ref). Most people conflate them until something goes wrong. This video uses visigit to show you both refs in the same graph, what happens when they drift apart, and exactly what fetch, pull, and push do to each pointer.
@@ -178,7 +178,7 @@ Every push, fetch, and pull you've run so far has been a black box — you've se
 The single-remote model from EP13 breaks down the moment you contribute to a project you don't have write access to — you need one remote that receives your work (origin, your fork) and a separate one that's the actual source of truth (upstream). This episode exists because the fork workflow is how most real open-source contribution happens, and conflating origin with "the project" is the single most common point of confusion for anyone's first pull request.
 
 #### YouTube Title
-> Git Fork Workflow: origin vs upstream Explained
+> Git Fork Workflow: origin vs upstream, Visualized
 
 #### YouTube Description
 > Contributing to an open-source project means juggling TWO remotes: origin (your fork) and upstream (the real project). Most tutorials gloss over this. This video shows both full sets of remote-tracking refs in one visigit graph, keeps your fork's main in sync with upstream, and walks through the exact commands for a clean feature-branch contribution — without ever pushing directly to upstream.
@@ -220,7 +220,7 @@ The single-remote model from EP13 breaks down the moment you contribute to a pro
 git stash doesn't have its own storage mechanism — it creates a genuine commit object, just one that most tools (and normal-mode visigit) don't show you by default. Realizing that a stash is a commit like any other, hanging off a ref called refs/stash, explains everything about how it behaves: why it has a SHA, why multiple stashes stack like a list, and why it isn't magic.
 
 #### YouTube Title
-> git stash Creates a Real Commit You Just Can't See
+> git stash Creates a Real Commit — Watch It Appear
 
 #### YouTube Description
 > git stash feels like a magic shelf that saves your work temporarily. What it actually does is create a special commit hanging off a ref called refs/stash — and that commit is only visible in visigit's verbose mode. This video shows you the hidden object, how stash entries stack up, and what pop, apply, and drop each do to the graph.
@@ -260,7 +260,7 @@ git stash doesn't have its own storage mechanism — it creates a genuine commit
 A commit's SHA is a hash of its content, and its content includes its parent's SHA — so replaying the exact same change onto a different parent necessarily produces a different SHA, even though nothing about the change itself changed. This is the clearest hands-on proof in the whole series that git identity is about content and lineage together, not just content, and it's the same fact that explains why rebase and amend also produce new SHAs.
 
 #### YouTube Title
-> git cherry-pick: Why the Commit SHA Always Changes
+> git cherry-pick: Watch the Commit SHA Always Change
 
 #### YouTube Description
 > cherry-pick lets you take one specific commit from any branch and replay it somewhere else. But the resulting commit always has a different SHA — even though the changes are identical. This video explains why using visigit: the parent commit is different, so the content of the commit object is different, so the SHA is different. You'll see it happen live.
@@ -300,7 +300,7 @@ A commit's SHA is a hash of its content, and its content includes its parent's S
 git almost never deletes a commit the instant it becomes unreachable — it just stops being able to find it through any ref, while the object itself sits untouched in .git/objects for weeks. reflog is the log of everywhere HEAD has pointed, which means "I lost my commits" is almost always actually "I lost the address," and this episode is about how to look the address back up.
 
 #### YouTube Title
-> git reflog: Find "Lost" Commits After reset --hard
+> git reflog: Watch "Lost" Commits Reappear
 
 #### YouTube Description
 > You ran git reset --hard or git rebase and now your commits are "gone." They're not — git keeps every commit in the object store for at least 30 days. git reflog shows you the history of where HEAD has been, giving you the SHA of every commit you've ever had checked out. This video shows you how to find and recover them using visigit to confirm the work is really still there.
@@ -341,7 +341,7 @@ git almost never deletes a commit the instant it becomes unreachable — it just
 ORIG_HEAD, MERGE_HEAD, FETCH_HEAD, CHERRY_PICK_HEAD, and BISECT_HEAD are not five unrelated features to memorize — they're the same pattern repeated five times: before doing something to HEAD that might need undoing or referencing later, git writes down where things stood in an ordinary ref file. Recognizing that pattern means the next unfamiliar ALL_CAPS_HEAD you see in git's output won't need a new mental model, just the one you already have.
 
 #### YouTube Title
-> ORIG_HEAD, FETCH_HEAD, and Git's Other Hidden Safety Refs
+> ORIG_HEAD, FETCH_HEAD: Watch Git's Hidden Safety Refs
 
 #### YouTube Description
 > You've seen them flash by: ORIG_HEAD after a reset, MERGE_HEAD during a conflict, FETCH_HEAD after a fetch. These are git's pointer files — special refs git writes so YOU (and git) can recover and reason about what just happened. Most tools hide them; visigit shows them. This video gathers them in one place so you understand the safety net under every "dangerous" command.
@@ -380,7 +380,7 @@ ORIG_HEAD, MERGE_HEAD, FETCH_HEAD, CHERRY_PICK_HEAD, and BISECT_HEAD are not fiv
 Most of what you do with git day to day isn't changing history, it's asking questions about history that already exists — who wrote this, when did this string first appear, why does this line look the way it does. This episode is a deliberate change of pace from "watch the graph change" to "watch the search narrow," because archaeology skills are just as core to using git well as the mutating commands are.
 
 #### YouTube Title
-> git blame, log -S, and log --grep: Find Who Changed What
+> git blame, log -S, and log --grep: See Who Changed What
 
 #### YouTube Description
 > Not every git episode is about changing the graph — sometimes you just need to search it. This video covers the three tools every developer eventually needs: git log --grep and --author to filter commits by metadata, git log -S (the "pickaxe") to find exactly when a string was added or removed, and git blame to see who last touched every line. We use a buried one-line bug to show all three working together to pin down the exact commit that caused it.
@@ -421,7 +421,7 @@ Most of what you do with git day to day isn't changing history, it's asking ques
 The index isn't required to match either your last commit or your current working tree exactly — it's a genuinely independent third state that you can shape by hand, one hunk at a time. Seeing the same file exist simultaneously as two different blobs, one staged and one not, is the clearest possible proof that "staging" is a real, separate editing step and not just a formality before commit.
 
 #### YouTube Title
-> git add -p: How Partial Staging Splits One File in Two
+> git add -p: Watch One File Split Into Two Blobs
 
 #### YouTube Description
 > git add -p lets you stage half a file's changes and leave the rest for later. Most people run it on faith. This video shows you exactly what it does to the object store: the SAME file appears in visigit's verbose mode in BOTH the Staged box and the Unstaged box at once, each with a DIFFERENT blob SHA. Commit, and only the staged blob becomes part of history — the rest stays right where you left it.

--- a/docs/curriculum/02-intermediate.md
+++ b/docs/curriculum/02-intermediate.md
@@ -17,7 +17,7 @@
 Merge and rebase solve the identical problem — integrating diverged work — with opposite philosophies: merge preserves exactly what happened (including the diamond shape), while rebase rewrites what happened into a story that never diverged in the first place. Neither is "correct"; they're a tradeoff between historical honesty and readability, and the rest of the advanced tier (interactive rebase, --onto, rerere) only makes sense once this tradeoff is clear.
 
 #### YouTube Title
-> git merge vs git rebase: Same Result, Completely Different Graph — See Both Live
+> git merge vs git rebase: Same Result, Different History
 
 #### YouTube Description
 > Merge and rebase both get your changes integrated, but they leave completely different histories behind. This video runs both operations on identical repos and shows you the graphs side by side: a merge creates a diamond with a merge commit; a rebase replays your commits with new SHAs onto a straight line. By the end you'll know which to choose and why.
@@ -57,7 +57,7 @@ Merge and rebase solve the identical problem — integrating diverged work — w
 Because rebase replays your commits one at a time instead of integrating them all at once like a merge, a single line of disputed code can produce a conflict on every commit that touches it — which is why rebase conflicts feel repetitive in a way merge conflicts don't. Understanding that each replay is its own mini-merge is what turns "why do I keep hitting the same conflict" into an expected, manageable part of the process instead of a sign something's gone wrong.
 
 #### YouTube Title
-> Rebase Conflicts Feel Like Whack-a-Mole — Here's Why, and How to Get Through One
+> git rebase Conflicts: Why They Repeat and How to Fix Them
 
 #### YouTube Description
 > A merge conflict stops you once. A rebase conflict can stop you once PER COMMIT being replayed, because rebase applies your commits one at a time. This video walks a real two-commit rebase conflict start to finish — resolving, continuing, resolving again — and shows the three escape hatches: --continue, --skip, and --abort. You'll see exactly why the same conflict can reappear and what visigit shows you while it's happening.
@@ -100,7 +100,7 @@ Because rebase replays your commits one at a time instead of integrating them al
 Your local main and origin/main are two separate, independently-moving pointers, and the second one is nothing but a cached snapshot of what the remote looked like at your last fetch — it does not update itself. This distinction is the root of most "but I thought I had the latest code" confusion, and once origin/* refs are visibly separate objects in the graph instead of an abstract idea, fetch/pull/push stop being magic syncing and become exactly what they are: explicit pointer updates you control.
 
 #### YouTube Title
-> origin/main Is Not main — How git fetch, pull, and push Move the Remote Tracking Pointer
+> origin/main Is Not main: How fetch, pull, and push Work
 
 #### YouTube Description
 > There are actually two "main" branches in a typical repo: your local main and origin/main (the remote tracking ref). Most people conflate them until something goes wrong. This video uses visigit to show you both refs in the same graph, what happens when they drift apart, and exactly what fetch, pull, and push do to each pointer.
@@ -139,7 +139,7 @@ Your local main and origin/main are two separate, independently-moving pointers,
 Every push, fetch, and pull you've run so far has been a black box — you've seen your side of the exchange but never the other end. Watching a real bare repository update live, side by side with your working copy, turns "the remote" from an abstract concept into a second, equally real graph that commits move between, which is the mental model every later remote-workflow episode assumes you already have.
 
 #### YouTube Title
-> See Both Sides of git push/fetch: Visualize Your Repo AND origin Side by Side
+> git push and fetch: Watch Your Repo AND origin Update Live
 
 #### YouTube Description
 > origin/main is a snapshot inside your repo — but where's the ACTUAL origin? In this video we put a bare "origin" repository on the same machine and run a second `visigit --monitor` on it, so you watch BOTH graphs at once. Now push, fetch, and pull aren't mysterious: you see commits leave your repo and land in origin, and origin/main catch up — live, side by side.
@@ -178,7 +178,7 @@ Every push, fetch, and pull you've run so far has been a black box — you've se
 The single-remote model from EP13 breaks down the moment you contribute to a project you don't have write access to — you need one remote that receives your work (origin, your fork) and a separate one that's the actual source of truth (upstream). This episode exists because the fork workflow is how most real open-source contribution happens, and conflating origin with "the project" is the single most common point of confusion for anyone's first pull request.
 
 #### YouTube Title
-> origin Isn't Always the Real Project — Meet upstream and the Fork Workflow
+> Git Fork Workflow: origin vs upstream Explained
 
 #### YouTube Description
 > Contributing to an open-source project means juggling TWO remotes: origin (your fork) and upstream (the real project). Most tutorials gloss over this. This video shows both full sets of remote-tracking refs in one visigit graph, keeps your fork's main in sync with upstream, and walks through the exact commands for a clean feature-branch contribution — without ever pushing directly to upstream.
@@ -220,7 +220,7 @@ The single-remote model from EP13 breaks down the moment you contribute to a pro
 git stash doesn't have its own storage mechanism — it creates a genuine commit object, just one that most tools (and normal-mode visigit) don't show you by default. Realizing that a stash is a commit like any other, hanging off a ref called refs/stash, explains everything about how it behaves: why it has a SHA, why multiple stashes stack like a list, and why it isn't magic.
 
 #### YouTube Title
-> git stash Creates a Real Commit — You Just Can't See It in Normal Mode
+> git stash Creates a Real Commit You Just Can't See
 
 #### YouTube Description
 > git stash feels like a magic shelf that saves your work temporarily. What it actually does is create a special commit hanging off a ref called refs/stash — and that commit is only visible in visigit's verbose mode. This video shows you the hidden object, how stash entries stack up, and what pop, apply, and drop each do to the graph.
@@ -260,7 +260,7 @@ git stash doesn't have its own storage mechanism — it creates a genuine commit
 A commit's SHA is a hash of its content, and its content includes its parent's SHA — so replaying the exact same change onto a different parent necessarily produces a different SHA, even though nothing about the change itself changed. This is the clearest hands-on proof in the whole series that git identity is about content and lineage together, not just content, and it's the same fact that explains why rebase and amend also produce new SHAs.
 
 #### YouTube Title
-> git cherry-pick Copies a Commit — But the SHA Changes Every Time. Here's Why.
+> git cherry-pick: Why the Commit SHA Always Changes
 
 #### YouTube Description
 > cherry-pick lets you take one specific commit from any branch and replay it somewhere else. But the resulting commit always has a different SHA — even though the changes are identical. This video explains why using visigit: the parent commit is different, so the content of the commit object is different, so the SHA is different. You'll see it happen live.
@@ -300,7 +300,7 @@ A commit's SHA is a hash of its content, and its content includes its parent's S
 git almost never deletes a commit the instant it becomes unreachable — it just stops being able to find it through any ref, while the object itself sits untouched in .git/objects for weeks. reflog is the log of everywhere HEAD has pointed, which means "I lost my commits" is almost always actually "I lost the address," and this episode is about how to look the address back up.
 
 #### YouTube Title
-> You Didn't Lose Your Commits — git reflog Is Git's Secret Safety Net
+> git reflog: Find "Lost" Commits After reset --hard
 
 #### YouTube Description
 > You ran git reset --hard or git rebase and now your commits are "gone." They're not — git keeps every commit in the object store for at least 30 days. git reflog shows you the history of where HEAD has been, giving you the SHA of every commit you've ever had checked out. This video shows you how to find and recover them using visigit to confirm the work is really still there.
@@ -341,7 +341,7 @@ git almost never deletes a commit the instant it becomes unreachable — it just
 ORIG_HEAD, MERGE_HEAD, FETCH_HEAD, CHERRY_PICK_HEAD, and BISECT_HEAD are not five unrelated features to memorize — they're the same pattern repeated five times: before doing something to HEAD that might need undoing or referencing later, git writes down where things stood in an ordinary ref file. Recognizing that pattern means the next unfamiliar ALL_CAPS_HEAD you see in git's output won't need a new mental model, just the one you already have.
 
 #### YouTube Title
-> The Hidden Refs That Save You: ORIG_HEAD, FETCH_HEAD, and git's Other Safety Nets
+> ORIG_HEAD, FETCH_HEAD, and Git's Other Hidden Safety Refs
 
 #### YouTube Description
 > You've seen them flash by: ORIG_HEAD after a reset, MERGE_HEAD during a conflict, FETCH_HEAD after a fetch. These are git's pointer files — special refs git writes so YOU (and git) can recover and reason about what just happened. Most tools hide them; visigit shows them. This video gathers them in one place so you understand the safety net under every "dangerous" command.
@@ -380,7 +380,7 @@ ORIG_HEAD, MERGE_HEAD, FETCH_HEAD, CHERRY_PICK_HEAD, and BISECT_HEAD are not fiv
 Most of what you do with git day to day isn't changing history, it's asking questions about history that already exists — who wrote this, when did this string first appear, why does this line look the way it does. This episode is a deliberate change of pace from "watch the graph change" to "watch the search narrow," because archaeology skills are just as core to using git well as the mutating commands are.
 
 #### YouTube Title
-> Who Wrote This Line, and Why? git blame, log -S, and log --grep Explained
+> git blame, log -S, and log --grep: Find Who Changed What
 
 #### YouTube Description
 > Not every git episode is about changing the graph — sometimes you just need to search it. This video covers the three tools every developer eventually needs: git log --grep and --author to filter commits by metadata, git log -S (the "pickaxe") to find exactly when a string was added or removed, and git blame to see who last touched every line. We use a buried one-line bug to show all three working together to pin down the exact commit that caused it.
@@ -421,7 +421,7 @@ Most of what you do with git day to day isn't changing history, it's asking ques
 The index isn't required to match either your last commit or your current working tree exactly — it's a genuinely independent third state that you can shape by hand, one hunk at a time. Seeing the same file exist simultaneously as two different blobs, one staged and one not, is the clearest possible proof that "staging" is a real, separate editing step and not just a formality before commit.
 
 #### YouTube Title
-> git add -p Splits One File Into Two Blobs — Watch It Happen in Verbose Mode
+> git add -p: How Partial Staging Splits One File in Two
 
 #### YouTube Description
 > git add -p lets you stage half a file's changes and leave the rest for later. Most people run it on faith. This video shows you exactly what it does to the object store: the SAME file appears in visigit's verbose mode in BOTH the Staged box and the Unstaged box at once, each with a DIFFERENT blob SHA. Commit, and only the staged blob becomes part of history — the rest stays right where you left it.

--- a/docs/curriculum/03-advanced.md
+++ b/docs/curriculum/03-advanced.md
@@ -17,7 +17,7 @@
 Every commit you've made in this series has been permanent the moment you made it — until now. Interactive rebase is git handing you an editable transcript of recent history: reorder lines, merge lines, delete lines, and git replays the result as if you'd committed it that way from the start. The one rule that makes this safe is the one this episode hammers on: only rewrite history nobody else has built on yet.
 
 #### YouTube Title
-> git rebase -i: Squash, Reorder, and Rewrite Commits
+> git rebase -i: Watch Squash, Reorder, and Rewrite
 
 #### YouTube Description
 > Interactive rebase lets you rewrite your local commit history before sharing it: squash five "WIP" commits into one, fix a typo in a commit message, drop a commit entirely, or reorder them. This video walks through each operation in visigit so you can see exactly which commit nodes change SHA, which disappear, and which survive untouched.
@@ -57,7 +57,7 @@ Every commit you've made in this series has been permanent the moment you made i
 "Squash" is a single English word covering two git operations with opposite mechanics: rebase -i squash rewrites commits before you ever merge, while merge --squash discards a branch's commit boundaries entirely at merge time and never even creates a merge commit. Conflating the two is an easy mistake with real consequences for what your history looks like afterward, and this episode exists specifically to make the difference impossible to un-see.
 
 #### YouTube Title
-> git merge --squash vs rebase -i squash: Not the Same Thing
+> git merge --squash vs rebase -i squash: See the Difference
 
 #### YouTube Description
 > "Squash" means two completely different things depending on which command you say it to. Interactive rebase's squash rewrites commits INSIDE your branch before you merge. git merge --squash discards your branch's commit boundaries entirely at merge time and produces a single-parent commit with no merge commit at all — this is exactly what GitHub's "Squash and merge" button does. This video shows both, side by side, plus the -X ours/-X theirs merge strategy options for auto-resolving conflicts in one direction.
@@ -96,7 +96,7 @@ Every commit you've made in this series has been permanent the moment you made i
 A plain git rebase always means "replay everything not already on the target," which only works if you want to keep every one of your branch's commits. --onto exists for the case that comes up constantly in real projects — your branch was built on the wrong foundation — by letting you name the exact exclusion boundary yourself instead of accepting whatever rebase would replay by default.
 
 #### YouTube Title
-> git rebase --onto: Fix a Branch Built on the Wrong Base
+> git rebase --onto: Watch a Branch Move to the Right Base
 
 #### YouTube Description
 > Plain git rebase replays every commit not already on your target. But what if your branch was built on top of ANOTHER branch you now want to skip entirely? git rebase --onto lets you name the exact exclusion boundary yourself. This video builds a three-branch chain, then replants the tip branch directly onto main — skipping the middle branch's commits completely — and shows exactly which commits get new SHAs and which vanish from the new history.
@@ -134,7 +134,7 @@ A plain git rebase always means "replay everything not already on the target," w
 A lightweight tag is structurally identical to a branch that never moves — just a named pointer at a commit. An annotated tag adds a whole extra object in between, with its own SHA, message, and signature support. Most people reach for lightweight tags out of habit; understanding what annotated tags actually buy you is what makes "always use -a for releases" a reasoned choice instead of a rule someone told you to follow.
 
 #### YouTube Title
-> git tag vs git tag -a: Lightweight vs Annotated Tags
+> git tag vs git tag -a: See Lightweight vs Annotated
 
 #### YouTube Description
 > A lightweight tag is just a ref that points to a commit — exactly like a branch, except it doesn't move. An annotated tag is a full git object with its own SHA, author, and message, sitting between the tag ref and the commit. This video shows you both in visigit's graph so you can see exactly what you're creating and why annotated tags are preferred for releases.
@@ -172,7 +172,7 @@ A lightweight tag is structurally identical to a branch that never moves — jus
 A bug hiding somewhere in 500 commits sounds like a linear search problem, but git bisect turns it into a logarithmic one — roughly 9 tests instead of 500. The mechanism is nothing more exotic than checking out the midpoint commit and asking a yes/no question, repeated; seeing HEAD jump to that midpoint in the graph is what makes the halving concrete instead of theoretical.
 
 #### YouTube Title
-> git bisect: Binary Search Your History to Find a Bug
+> git bisect: Watch a Binary Search Find Your Bug
 
 #### YouTube Description
 > A bug exists now that didn't exist six months ago. git bisect performs a binary search through your commit history, halving the search space at each step. This video shows the process in visigit: watch HEAD move through the graph as bisect narrows in on the exact commit that introduced the bug — often in just 7-10 steps through hundreds of commits. We also cover the --no-checkout variant, which is the only mode where git actually writes a BISECT_HEAD ref instead of just moving HEAD.
@@ -214,7 +214,7 @@ A bug hiding somewhere in 500 commits sounds like a linear search problem, but g
 git's working tree and its object store are conceptually separate, and worktree is the feature that makes that separation visible: multiple working trees, each with their own checked-out branch, all sharing the exact same underlying object database. Once you've seen two directories on disk both reading from one .git, "I need to stash to switch branches" stops being a fact of life and becomes an avoidable workaround.
 
 #### YouTube Title
-> git worktree: Check Out Two Branches Without Stashing
+> git worktree: See Two Branches Checked Out at Once
 
 #### YouTube Description
 > Normally you can only have one branch checked out at a time. git worktree lets you check out additional branches into separate directories on disk — each with its own working tree. You can run a server on main while developing on a feature branch, without stashing or switching. This video uses visigit's branch mode to show all active worktrees alongside the branch topology.
@@ -252,7 +252,7 @@ git's working tree and its object store are conceptually separate, and worktree 
 A normal push is git refusing to lose information — it rejects any update that isn't a fast-forward. --force is you explicitly telling git that's fine, replace whatever's there. The danger isn't the command itself, it's that "whatever's there" might be a teammate's work you never fetched, which is exactly what this episode makes visible before it becomes a real incident.
 
 #### YouTube Title
-> git push --force: How It Destroys Your Team's History
+> git push --force: Watch It Destroy Your Team's History
 
 #### YouTube Description
 > Force push rewrites the remote ref to point at your local commit chain, discarding everything the remote had that you don't. If a teammate pushed after you last pulled, their commits are simply gone from the remote. This video makes the danger concrete by showing you exactly what the graph looks like before and after a force push — and why --force-with-lease is a safer alternative.

--- a/docs/curriculum/03-advanced.md
+++ b/docs/curriculum/03-advanced.md
@@ -17,7 +17,7 @@
 Every commit you've made in this series has been permanent the moment you made it — until now. Interactive rebase is git handing you an editable transcript of recent history: reorder lines, merge lines, delete lines, and git replays the result as if you'd committed it that way from the start. The one rule that makes this safe is the one this episode hammers on: only rewrite history nobody else has built on yet.
 
 #### YouTube Title
-> git rebase -i: Squash, Reorder, and Rewrite Commits — Watch the Graph Change
+> git rebase -i: Squash, Reorder, and Rewrite Commits
 
 #### YouTube Description
 > Interactive rebase lets you rewrite your local commit history before sharing it: squash five "WIP" commits into one, fix a typo in a commit message, drop a commit entirely, or reorder them. This video walks through each operation in visigit so you can see exactly which commit nodes change SHA, which disappear, and which survive untouched.
@@ -57,7 +57,7 @@ Every commit you've made in this series has been permanent the moment you made i
 "Squash" is a single English word covering two git operations with opposite mechanics: rebase -i squash rewrites commits before you ever merge, while merge --squash discards a branch's commit boundaries entirely at merge time and never even creates a merge commit. Conflating the two is an easy mistake with real consequences for what your history looks like afterward, and this episode exists specifically to make the difference impossible to un-see.
 
 #### YouTube Title
-> git merge --squash Is Not the Same "Squash" as rebase -i — Here's the Graph Proof
+> git merge --squash vs rebase -i squash: Not the Same Thing
 
 #### YouTube Description
 > "Squash" means two completely different things depending on which command you say it to. Interactive rebase's squash rewrites commits INSIDE your branch before you merge. git merge --squash discards your branch's commit boundaries entirely at merge time and produces a single-parent commit with no merge commit at all — this is exactly what GitHub's "Squash and merge" button does. This video shows both, side by side, plus the -X ours/-X theirs merge strategy options for auto-resolving conflicts in one direction.
@@ -96,7 +96,7 @@ Every commit you've made in this series has been permanent the moment you made i
 A plain git rebase always means "replay everything not already on the target," which only works if you want to keep every one of your branch's commits. --onto exists for the case that comes up constantly in real projects — your branch was built on the wrong foundation — by letting you name the exact exclusion boundary yourself instead of accepting whatever rebase would replay by default.
 
 #### YouTube Title
-> My Branch Is Based on the Wrong Branch — git rebase --onto Fixes It Without Starting Over
+> git rebase --onto: Fix a Branch Built on the Wrong Base
 
 #### YouTube Description
 > Plain git rebase replays every commit not already on your target. But what if your branch was built on top of ANOTHER branch you now want to skip entirely? git rebase --onto lets you name the exact exclusion boundary yourself. This video builds a three-branch chain, then replants the tip branch directly onto main — skipping the middle branch's commits completely — and shows exactly which commits get new SHAs and which vanish from the new history.
@@ -134,7 +134,7 @@ A plain git rebase always means "replay everything not already on the target," w
 A lightweight tag is structurally identical to a branch that never moves — just a named pointer at a commit. An annotated tag adds a whole extra object in between, with its own SHA, message, and signature support. Most people reach for lightweight tags out of habit; understanding what annotated tags actually buy you is what makes "always use -a for releases" a reasoned choice instead of a rule someone told you to follow.
 
 #### YouTube Title
-> git tag vs git tag -a: Two Different Graph Nodes for Two Different Objects
+> git tag vs git tag -a: Lightweight vs Annotated Tags
 
 #### YouTube Description
 > A lightweight tag is just a ref that points to a commit — exactly like a branch, except it doesn't move. An annotated tag is a full git object with its own SHA, author, and message, sitting between the tag ref and the commit. This video shows you both in visigit's graph so you can see exactly what you're creating and why annotated tags are preferred for releases.
@@ -172,7 +172,7 @@ A lightweight tag is structurally identical to a branch that never moves — jus
 A bug hiding somewhere in 500 commits sounds like a linear search problem, but git bisect turns it into a logarithmic one — roughly 9 tests instead of 500. The mechanism is nothing more exotic than checking out the midpoint commit and asking a yes/no question, repeated; seeing HEAD jump to that midpoint in the graph is what makes the halving concrete instead of theoretical.
 
 #### YouTube Title
-> git bisect: Binary Search Your Commit History to Find Exactly When a Bug Appeared
+> git bisect: Binary Search Your History to Find a Bug
 
 #### YouTube Description
 > A bug exists now that didn't exist six months ago. git bisect performs a binary search through your commit history, halving the search space at each step. This video shows the process in visigit: watch HEAD move through the graph as bisect narrows in on the exact commit that introduced the bug — often in just 7-10 steps through hundreds of commits. We also cover the --no-checkout variant, which is the only mode where git actually writes a BISECT_HEAD ref instead of just moving HEAD.
@@ -214,7 +214,7 @@ A bug hiding somewhere in 500 commits sounds like a linear search problem, but g
 git's working tree and its object store are conceptually separate, and worktree is the feature that makes that separation visible: multiple working trees, each with their own checked-out branch, all sharing the exact same underlying object database. Once you've seen two directories on disk both reading from one .git, "I need to stash to switch branches" stops being a fact of life and becomes an avoidable workaround.
 
 #### YouTube Title
-> git worktree: Check Out Two Branches at the Same Time Without Stashing
+> git worktree: Check Out Two Branches Without Stashing
 
 #### YouTube Description
 > Normally you can only have one branch checked out at a time. git worktree lets you check out additional branches into separate directories on disk — each with its own working tree. You can run a server on main while developing on a feature branch, without stashing or switching. This video uses visigit's branch mode to show all active worktrees alongside the branch topology.
@@ -252,7 +252,7 @@ git's working tree and its object store are conceptually separate, and worktree 
 A normal push is git refusing to lose information — it rejects any update that isn't a fast-forward. --force is you explicitly telling git that's fine, replace whatever's there. The danger isn't the command itself, it's that "whatever's there" might be a teammate's work you never fetched, which is exactly what this episode makes visible before it becomes a real incident.
 
 #### YouTube Title
-> git push --force Is Destroying Your Team's History — Watch It Happen in the Graph
+> git push --force: How It Destroys Your Team's History
 
 #### YouTube Description
 > Force push rewrites the remote ref to point at your local commit chain, discarding everything the remote had that you don't. If a teammate pushed after you last pulled, their commits are simply gone from the remote. This video makes the danger concrete by showing you exactly what the graph looks like before and after a force push — and why --force-with-lease is a safer alternative.

--- a/docs/curriculum/04-internals.md
+++ b/docs/curriculum/04-internals.md
@@ -17,7 +17,7 @@
 Every git command you've run in this series has ultimately been manipulating exactly four object types — blob, tree, commit, tag — hashed and stored by content. This episode is the one where the abstraction finally opens up: "commit" stops being a verb you perform and becomes a noun you can point at, with a SHA, a tree, and a parent, exactly like every other object in the store.
 
 #### YouTube Title
-> Inside a git commit: blob, tree, commit Objects Explained with a Live Object Graph
+> Inside a git commit: blob, tree, and commit Objects
 
 #### YouTube Description
 > Every git commit creates three types of objects: blobs (file contents), trees (directory listings), and a commit object (metadata + pointer to root tree). This video uses visigit's verbose mode to show you all three appearing in the graph the moment you run git commit — and explains the fourth object type (annotated tags) while it's fresh. By the end you'll understand exactly what git is storing on disk.
@@ -58,7 +58,7 @@ Every git command you've run in this series has ultimately been manipulating exa
 Including one repository inside another sounds like one problem, but git offers two genuinely different solutions to it: a submodule stores a pointer (a gitlink) to another repo's commit, while a subtree merges that repo's actual files into yours as ordinary blobs. They look similar from the command line and are almost opposite at the object level, which is exactly why picking between them by habit instead of understanding causes so much team friction.
 
 #### YouTube Title
-> Submodules vs Subtrees: One Stores a Pointer, the Other Merges the Files — See the Difference
+> git Submodule vs Subtree: Pointer vs Merged Files
 
 #### YouTube Description
 > Two ways to include one repo inside another, and they couldn't be more different under the hood. A submodule stores a gitlink — a pointer to a specific commit in another repo — which visigit shows as a distinct node. A subtree merges the other repo's files directly into your tree as ordinary blobs, with its history as a second parent. This video opens both in verbose mode so you can see exactly what git stores in each case.
@@ -98,7 +98,7 @@ Including one repository inside another sounds like one problem, but git offers 
 Content-addressable storage means identical content always hashes to the identical object, no matter how many commits or files reference it — git isn't storing a thousand copies of your README, it's storing one blob with a thousand pointers to it. This is the single idea that makes git's storage efficient at any scale, and it's also why a rename with no content change is nearly free.
 
 #### YouTube Title
-> Same File Content = Same SHA: How Git Avoids Storing Duplicates Across Commits
+> Same File, Same SHA: How Git Avoids Storing Duplicates
 
 #### YouTube Description
 > Every git object is identified by the SHA of its content. This means if you commit a file and don't change it, the next commit reuses exactly the same blob object — the same node in the graph. This video makes content-addressable storage visible by showing two commits in verbose mode sharing a blob node, and then showing what happens when you do change the file.
@@ -137,7 +137,7 @@ Content-addressable storage means identical content always hashes to the identic
 "git add stages the file" undersells what actually happens: git computes a hash of your content and writes a real blob object to .git/objects immediately, before you've committed anything. The staging area isn't a to-do list of filenames, it's a list of blob SHAs — and once you've watched that blob appear in the object store the instant you run add, the difference between the working tree, the index, and HEAD stops being three abstract states and becomes three concrete sets of pointers you can inspect.
 
 #### YouTube Title
-> git add Creates a Blob Object Before You Even Commit — Watch It Appear in Verbose Mode
+> git add Creates a Blob Object Before You Even Commit
 
 #### YouTube Description
 > Most tutorials say "git add stages the file." What it actually does is compute the SHA of your file's content, write a blob object to .git/objects, and record the SHA in the index. The blob exists even before you commit. visigit's verbose mode makes this visible: the staged file appears in the graph with its blob SHA the moment you run git add — no commit required.
@@ -178,7 +178,7 @@ Content-addressable storage means identical content always hashes to the identic
 Every diagram this series has drawn is a picture of real files sitting in .git/objects, and this episode is where you stop trusting the picture and go read the bytes yourself. cat-file, hash-object, and a raw ls of the object directory are the ground truth that everything else in the series has been representing — seeing the same SHA in the terminal and in the diagram is the moment the abstraction fully collapses into "it's just files on disk."
 
 #### YouTube Title
-> What's Actually Inside .git/objects? Unpacking Blobs, Trees, and Commits with git cat-file
+> git cat-file: What's Actually Inside .git/objects
 
 #### YouTube Description
 > You've seen the object graph in visigit. Now let's open the objects themselves. git cat-file -p <sha> prints the raw content of any git object. In this video we crack open blobs, trees, and commits in the terminal alongside the verbose diagram — showing you exactly what bytes are stored on disk and how git's SHA hash is computed. We also explain how pack files compress thousands of loose objects into an efficient bundle.
@@ -220,7 +220,7 @@ Every diagram this series has drawn is a picture of real files sitting in .git/o
 A shallow clone's oldest commit renders with no parent, exactly like a true repository root or an orphan branch — but it's neither; it's an honest gap where parent objects were deliberately never downloaded. Recognizing that "parentless in the graph" doesn't always mean "root of history" is what keeps a shallow clone from looking like data corruption, and understanding the boundary mechanism is what makes fetch --unshallow's "graph grows backward" moment make sense instead of feeling like magic.
 
 #### YouTube Title
-> Shallow Clones: How git clone --depth 1 Fakes a Repo With No History
+> git clone --depth 1: How Shallow Clones Fake No History
 
 #### YouTube Description
 > git clone --depth 1 downloads a huge repo almost instantly by simply not fetching most of its history. But the oldest commit you DO have still needs to render as a valid DAG node — so git fakes it as parentless, even though it isn't really the repo's root. This video shows that fake boundary commit live in visigit, opens the raw .git/shallow file that makes it possible, and watches the graph grow backward the instant you run git fetch --unshallow.

--- a/docs/curriculum/04-internals.md
+++ b/docs/curriculum/04-internals.md
@@ -17,7 +17,7 @@
 Every git command you've run in this series has ultimately been manipulating exactly four object types — blob, tree, commit, tag — hashed and stored by content. This episode is the one where the abstraction finally opens up: "commit" stops being a verb you perform and becomes a noun you can point at, with a SHA, a tree, and a parent, exactly like every other object in the store.
 
 #### YouTube Title
-> Inside a git commit: blob, tree, and commit Objects
+> Watch Inside a git commit: blob, tree, and commit
 
 #### YouTube Description
 > Every git commit creates three types of objects: blobs (file contents), trees (directory listings), and a commit object (metadata + pointer to root tree). This video uses visigit's verbose mode to show you all three appearing in the graph the moment you run git commit — and explains the fourth object type (annotated tags) while it's fresh. By the end you'll understand exactly what git is storing on disk.
@@ -58,7 +58,7 @@ Every git command you've run in this series has ultimately been manipulating exa
 Including one repository inside another sounds like one problem, but git offers two genuinely different solutions to it: a submodule stores a pointer (a gitlink) to another repo's commit, while a subtree merges that repo's actual files into yours as ordinary blobs. They look similar from the command line and are almost opposite at the object level, which is exactly why picking between them by habit instead of understanding causes so much team friction.
 
 #### YouTube Title
-> git Submodule vs Subtree: Pointer vs Merged Files
+> git Submodule vs Subtree: See Pointer vs Merged Files
 
 #### YouTube Description
 > Two ways to include one repo inside another, and they couldn't be more different under the hood. A submodule stores a gitlink — a pointer to a specific commit in another repo — which visigit shows as a distinct node. A subtree merges the other repo's files directly into your tree as ordinary blobs, with its history as a second parent. This video opens both in verbose mode so you can see exactly what git stores in each case.
@@ -98,7 +98,7 @@ Including one repository inside another sounds like one problem, but git offers 
 Content-addressable storage means identical content always hashes to the identical object, no matter how many commits or files reference it — git isn't storing a thousand copies of your README, it's storing one blob with a thousand pointers to it. This is the single idea that makes git's storage efficient at any scale, and it's also why a rename with no content change is nearly free.
 
 #### YouTube Title
-> Same File, Same SHA: How Git Avoids Storing Duplicates
+> Same File, Same SHA: Watch Git Avoid Storing Duplicates
 
 #### YouTube Description
 > Every git object is identified by the SHA of its content. This means if you commit a file and don't change it, the next commit reuses exactly the same blob object — the same node in the graph. This video makes content-addressable storage visible by showing two commits in verbose mode sharing a blob node, and then showing what happens when you do change the file.
@@ -137,7 +137,7 @@ Content-addressable storage means identical content always hashes to the identic
 "git add stages the file" undersells what actually happens: git computes a hash of your content and writes a real blob object to .git/objects immediately, before you've committed anything. The staging area isn't a to-do list of filenames, it's a list of blob SHAs — and once you've watched that blob appear in the object store the instant you run add, the difference between the working tree, the index, and HEAD stops being three abstract states and becomes three concrete sets of pointers you can inspect.
 
 #### YouTube Title
-> git add Creates a Blob Object Before You Even Commit
+> Watch git add Create a Blob Object Before You Commit
 
 #### YouTube Description
 > Most tutorials say "git add stages the file." What it actually does is compute the SHA of your file's content, write a blob object to .git/objects, and record the SHA in the index. The blob exists even before you commit. visigit's verbose mode makes this visible: the staged file appears in the graph with its blob SHA the moment you run git add — no commit required.
@@ -178,7 +178,7 @@ Content-addressable storage means identical content always hashes to the identic
 Every diagram this series has drawn is a picture of real files sitting in .git/objects, and this episode is where you stop trusting the picture and go read the bytes yourself. cat-file, hash-object, and a raw ls of the object directory are the ground truth that everything else in the series has been representing — seeing the same SHA in the terminal and in the diagram is the moment the abstraction fully collapses into "it's just files on disk."
 
 #### YouTube Title
-> git cat-file: What's Actually Inside .git/objects
+> git cat-file: See What's Actually Inside .git/objects
 
 #### YouTube Description
 > You've seen the object graph in visigit. Now let's open the objects themselves. git cat-file -p <sha> prints the raw content of any git object. In this video we crack open blobs, trees, and commits in the terminal alongside the verbose diagram — showing you exactly what bytes are stored on disk and how git's SHA hash is computed. We also explain how pack files compress thousands of loose objects into an efficient bundle.
@@ -220,7 +220,7 @@ Every diagram this series has drawn is a picture of real files sitting in .git/o
 A shallow clone's oldest commit renders with no parent, exactly like a true repository root or an orphan branch — but it's neither; it's an honest gap where parent objects were deliberately never downloaded. Recognizing that "parentless in the graph" doesn't always mean "root of history" is what keeps a shallow clone from looking like data corruption, and understanding the boundary mechanism is what makes fetch --unshallow's "graph grows backward" moment make sense instead of feeling like magic.
 
 #### YouTube Title
-> git clone --depth 1: How Shallow Clones Fake No History
+> git clone --depth 1: Watch a Shallow Clone Fake History
 
 #### YouTube Description
 > git clone --depth 1 downloads a huge repo almost instantly by simply not fetching most of its history. But the oldest commit you DO have still needs to render as a valid DAG node — so git fakes it as parentless, even though it isn't really the repo's root. This video shows that fake boundary commit live in visigit, opens the raw .git/shallow file that makes it possible, and watches the graph grow backward the instant you run git fetch --unshallow.

--- a/docs/curriculum/05-reference.md
+++ b/docs/curriculum/05-reference.md
@@ -61,7 +61,7 @@ None of the shortcuts and identity settings in this episode touch the object gra
 A line-ending mismatch produces a diff that touches every line of a file with a change that isn't really there, and core.autocrlf only patches over the symptom on your machine — .gitattributes is the fix that travels with the repository itself, because it's a committed file, not a personal setting. This episode exists because line-ending "diff bombs" are one of the most common sources of team friction, and the fix is almost always simpler than the confusion it causes.
 
 #### YouTube Title
-> Line Endings, autocrlf, and .gitattributes Explained
+> See Line Endings Fixed: autocrlf vs .gitattributes
 
 #### YouTube Description
 > Windows uses CRLF, Unix uses LF, and a repo with mixed line endings produces diffs that touch every line of every file for no reason. This episode covers core.autocrlf (a personal, local setting) and the better fix — a committed .gitattributes file that makes line-ending rules part of the repo itself — plus the one command that cleanly renormalizes an already-mixed repo.
@@ -96,7 +96,7 @@ A line-ending mismatch produces a diff that touches every line of a file with a 
 rerere is built on a simple observation: a conflict is defined by its content, not by when it happens, so if you've resolved this exact conflict before, git can just remember and reapply your resolution. This matters most for exactly the situation that makes rebase conflicts painful (EP12) — a long-lived branch rebased repeatedly against a moving main — where rerere turns "resolve this again" into "already handled."
 
 #### YouTube Title
-> git rerere: Stop Resolving the Same Conflict Twice
+> git rerere: Watch the Same Rebase Need Zero Effort
 
 #### YouTube Description
 > Rebasing a long-lived branch against a moving main means resolving the SAME conflict over and over. git rerere ("reuse recorded resolution") remembers how you resolved a conflict and auto-applies that resolution the next time it sees the identical conflict. This episode runs the same rebase twice — once manually, once with rerere doing the work — on an identical resulting graph, to make clear that rerere changes your effort, not your history.
@@ -133,7 +133,7 @@ rerere is built on a simple observation: a conflict is defined by its content, n
 A commit's author field is plain text that anyone with write access can set to anything — signing is the mechanism that actually binds a commit's exact content to a cryptographic identity, checkable by anyone, forever. This episode matters more every year as supply-chain attacks target exactly this gap: an unsigned commit's authorship is a claim, a signed one's is a proof.
 
 #### YouTube Title
-> Signing Git Commits and Tags: Proving It Was Really You
+> Signing Git Commits and Tags: See the Proof It's You
 
 #### YouTube Description
 > A commit's author field is just a text string; anyone can type your name and email into it. Signing binds a real cryptographic identity to a commit's exact content, permanently. This episode covers both the GPG path and the newer, simpler SSH-key signing path, opens a signed commit with git cat-file to show exactly where the signature lives inside the object, and covers signed tags too.
@@ -171,7 +171,7 @@ A commit's author field is plain text that anyone with write access can set to a
 Shallow clones (EP34) trim how much history you download; sparse checkout and partial clone trim something else entirely — which files exist on disk and which blobs ever get fetched — and the two axes are independent and combinable. This episode exists because as repos grow into monorepo territory, "clone everything" stops being a viable default, and understanding which knob controls which resource is what makes working in a huge repo feel normal instead of painful.
 
 #### YouTube Title
-> git sparse-checkout and Partial Clone for Monorepos
+> git sparse-checkout and Partial Clone: Watch It Shrink
 
 #### YouTube Description
 > Shallow clones (EP34) trim history depth. Sparse checkout and partial clone trim a completely different axis: which files exist on disk and which blobs ever get downloaded. This episode clones with --filter=blob:none so file contents fetch lazily, then narrows the working tree to one directory with sparse-checkout — while the full commit graph, for every project in the monorepo, stays completely intact and visible.

--- a/docs/curriculum/05-reference.md
+++ b/docs/curriculum/05-reference.md
@@ -22,7 +22,7 @@ walkthroughs.
 None of the shortcuts and identity settings in this episode touch the object graph at all — config lives entirely outside the DAG, in plain text files that just happen to control who git says you are and what your commands expand to. Understanding the three-scope precedence (system, global, local) is what stops "why does this repo use a different email" from being a mystery.
 
 #### YouTube Title
-> git config --global Explained: Identity, Aliases, and the Three Config Files That Run Everything
+> git config --global: Identity, Aliases, and Config Files
 
 #### YouTube Description
 > Every commit's author field, every default editor, every shortcut you type — it all comes from git config. This episode has no diagram, because config doesn't touch refs or objects; it's pure setup. We cover the three config scopes and their precedence, building real aliases (including a shell-out alias), and where every setting physically lives on disk.
@@ -61,7 +61,7 @@ None of the shortcuts and identity settings in this episode touch the object gra
 A line-ending mismatch produces a diff that touches every line of a file with a change that isn't really there, and core.autocrlf only patches over the symptom on your machine — .gitattributes is the fix that travels with the repository itself, because it's a committed file, not a personal setting. This episode exists because line-ending "diff bombs" are one of the most common sources of team friction, and the fix is almost always simpler than the confusion it causes.
 
 #### YouTube Title
-> "Every File Changed" But You Didn't Touch Anything: Line Endings, autocrlf, and .gitattributes
+> Line Endings, autocrlf, and .gitattributes Explained
 
 #### YouTube Description
 > Windows uses CRLF, Unix uses LF, and a repo with mixed line endings produces diffs that touch every line of every file for no reason. This episode covers core.autocrlf (a personal, local setting) and the better fix — a committed .gitattributes file that makes line-ending rules part of the repo itself — plus the one command that cleanly renormalizes an already-mixed repo.
@@ -96,7 +96,7 @@ A line-ending mismatch produces a diff that touches every line of a file with a 
 rerere is built on a simple observation: a conflict is defined by its content, not by when it happens, so if you've resolved this exact conflict before, git can just remember and reapply your resolution. This matters most for exactly the situation that makes rebase conflicts painful (EP12) — a long-lived branch rebased repeatedly against a moving main — where rerere turns "resolve this again" into "already handled."
 
 #### YouTube Title
-> git rerere: Stop Resolving the Same Rebase Conflict Every Single Time
+> git rerere: Stop Resolving the Same Conflict Twice
 
 #### YouTube Description
 > Rebasing a long-lived branch against a moving main means resolving the SAME conflict over and over. git rerere ("reuse recorded resolution") remembers how you resolved a conflict and auto-applies that resolution the next time it sees the identical conflict. This episode runs the same rebase twice — once manually, once with rerere doing the work — on an identical resulting graph, to make clear that rerere changes your effort, not your history.
@@ -133,7 +133,7 @@ rerere is built on a simple observation: a conflict is defined by its content, n
 A commit's author field is plain text that anyone with write access can set to anything — signing is the mechanism that actually binds a commit's exact content to a cryptographic identity, checkable by anyone, forever. This episode matters more every year as supply-chain attacks target exactly this gap: an unsigned commit's authorship is a claim, a signed one's is a proof.
 
 #### YouTube Title
-> Anyone Can Put Your Name on a Commit — Signing Proves It Was Actually You
+> Signing Git Commits and Tags: Proving It Was Really You
 
 #### YouTube Description
 > A commit's author field is just a text string; anyone can type your name and email into it. Signing binds a real cryptographic identity to a commit's exact content, permanently. This episode covers both the GPG path and the newer, simpler SSH-key signing path, opens a signed commit with git cat-file to show exactly where the signature lives inside the object, and covers signed tags too.
@@ -171,7 +171,7 @@ A commit's author field is plain text that anyone with write access can set to a
 Shallow clones (EP34) trim how much history you download; sparse checkout and partial clone trim something else entirely — which files exist on disk and which blobs ever get fetched — and the two axes are independent and combinable. This episode exists because as repos grow into monorepo territory, "clone everything" stops being a viable default, and understanding which knob controls which resource is what makes working in a huge repo feel normal instead of painful.
 
 #### YouTube Title
-> Sparse Checkout and Partial Clone: Work in a 50-Project Monorepo Without Downloading All 50
+> git sparse-checkout and Partial Clone for Monorepos
 
 #### YouTube Description
 > Shallow clones (EP34) trim history depth. Sparse checkout and partial clone trim a completely different axis: which files exist on disk and which blobs ever get downloaded. This episode clones with --filter=blob:none so file contents fetch lazily, then narrows the working tree to one directory with sparse-checkout — while the full commit graph, for every project in the monorepo, stays completely intact and visible.


### PR DESCRIPTION
Closes #63.

## Audit findings
- **All 39 episode titles exceeded YouTube's practical truncation length** (~60 chars in the suggested-videos sidebar/mobile search, ~70 on desktop). Longest was 97 characters.
- Several titles buried the actual search term (the git command/concept) behind a curiosity-hook clause, past where mobile truncates -- e.g. `You Didn't Lose Your Commits — git reflog Is Git's Secret Safety Net` doesn't surface "git reflog" until word 6+.
- Descriptions were re-audited against the same front-loading concern (YouTube's ~100-char snippet cutoff) but were already well-optimized -- left unchanged.

## What changed
All 39 `#### YouTube Title` lines across `docs/curriculum/*.md` rewritten to <=65 characters (now ranging 46-59), with the searchable git command/concept front-loaded in the first ~40 characters. Curiosity hooks moved to the back half of the title where they still exist.

Nothing else changed: outlines, "Why This Matters" sections, commands covered, and the README's Series Overview table (which reflects each episode's internal descriptive/H3 title, not the YouTube-facing title, so it's a different piece of copy and out of scope here) are untouched.

## Test plan
- [x] `git diff --stat` confirms exactly 39 lines changed (one title per episode), no other content touched
- [x] No CRLF line endings introduced
- [x] All 6 files well under the 100KB CI limit
- [x] All 39 new titles verified <=65 chars via script