### PR TITLE
Add FUNDING.yml to enable the repo Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: rcronk


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` with `github: rcronk` so the Sponsors button appears on the repository (profile is live at https://github.com/sponsors/rcronk)

Closes #65

## Test plan
- [ ] CI green (docs/config-only change; no code touched)
- [ ] After merge to develop and eventually main, verify the Sponsors button renders on the repo page